### PR TITLE
refactor: extract _common helpers and clean up jenkins/scripts

### DIFF
--- a/jenkins/scripts/_common.py
+++ b/jenkins/scripts/_common.py
@@ -1,0 +1,106 @@
+"""Shared helpers for the release-analyze-reco-profiling scripts.
+
+The Jenkins inline shell calls each script with `--release`, `--architecture`,
+`--workflow` and reads outputs from the script's working directory before
+xrdcopy'ing them to EOS. This module centralizes:
+
+- The hardcoded EOS paths the scripts read/write
+- The argparse surface every script duplicates
+- The "skip this workflow at step X" gating that lives in the inline shell
+  AND in several scripts
+- Path-builder helpers so call sites don't keep concatenating strings
+
+Anything user-visible (CLI flags, output filenames, exit semantics) is held
+fixed — refactoring here must not change the contract observed by Jenkins.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Iterable
+
+# ── Filesystem layout ────────────────────────────────────────────────────────
+# Source of profiling data, populated by `release-run-reco-profiling`.
+DATA_DIR = "/eos/cms/store/user/cmsbuild/profiling/data"
+
+# Web-publishing area, written via xrdcopy by the Jenkins inline shell.
+RESULT_PATH = "/eos/project/c/cmsweb/www/reco-prof/results"
+
+# Public URL prefix for everything under RESULT_PATH (used by make_webpage.py).
+RESULT_ADDRESS = "http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/"
+
+# ── Workflow gating ──────────────────────────────────────────────────────────
+# These match the `if [ "$WORKFLOW" != ... ]` guards in the Jenkins inline shell.
+# Keep them in sync with config.xml when the shell is eventually refreshed.
+_NO_SUMMARY_WORKFLOWS = {"136.889", "140.047"}
+_EXTENDED_STEP_WORKFLOWS = {"140.56", "159.03"}
+_NO_EVENTSIZE_WORKFLOWS = _NO_SUMMARY_WORKFLOWS | _EXTENDED_STEP_WORKFLOWS
+
+
+def steps_for(workflow: str) -> list[str]:
+    """Steps to analyze for a given workflow.
+
+    140.56 / 159.03 expose step2 (DIGI) in addition to the common 3/4/5.
+    """
+    if workflow in _EXTENDED_STEP_WORKFLOWS:
+        return ["step2", "step3", "step4", "step5"]
+    return ["step3", "step4", "step5"]
+
+
+def skip_summary(workflow: str) -> bool:
+    """True when the inline shell skips Time_Mem_Summary + summary_plot for this workflow."""
+    return workflow in _NO_SUMMARY_WORKFLOWS
+
+
+def skip_eventsize(workflow: str) -> bool:
+    """True when the inline shell skips eventsize / igprof / comparison for this workflow."""
+    return workflow in _NO_EVENTSIZE_WORKFLOWS
+
+
+# ── Path helpers ─────────────────────────────────────────────────────────────
+def data_dir(release: str, architecture: str, workflow: str, *, base: str = DATA_DIR) -> str:
+    """Absolute path to the EOS data directory for a single (release, arch, wf)."""
+    return os.path.join(base, release, architecture, workflow)
+
+
+def step_file(release: str, architecture: str, workflow: str, step: str, suffix: str,
+              *, base: str = DATA_DIR) -> str:
+    """Path to <DATA>/<release>/<arch>/<wf>/<step><suffix>.
+
+    Examples:
+        step_file(r, a, w, 'step3', '.root')                  -> .../step3.root
+        step_file(r, a, w, 'step3', '_TimeMemoryInfo.log')    -> .../step3_TimeMemoryInfo.log
+    """
+    return os.path.join(data_dir(release, architecture, workflow, base=base), f"{step}{suffix}")
+
+
+def result_subdir(*parts: str) -> str:
+    """Absolute path under RESULT_PATH built from path components."""
+    return os.path.join(RESULT_PATH, *parts)
+
+
+# ── argparse surface ─────────────────────────────────────────────────────────
+def make_parser(description: str = "", *, need: Iterable[str] = ("release", "architecture", "workflow"),
+                extra: Iterable[tuple[str, dict]] = ()) -> argparse.ArgumentParser:
+    """Build the standard parser the inline shell expects.
+
+    `need` selects which of release/architecture/workflow to expose; all default
+    to None to preserve the historical "optional but expected" behaviour.
+
+    `extra` is a list of (flag, kwargs) pairs for script-specific options.
+    """
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "--profile-data", type=str, default=DATA_DIR,
+        help="profiling data location (default: %(default)s)",
+    )
+    if "release" in need:
+        parser.add_argument("--release", type=str, default=None, help="CMSSW release")
+    if "architecture" in need:
+        parser.add_argument("--architecture", type=str, default=None, help="architecture for release")
+    if "workflow" in need:
+        parser.add_argument("--workflow", type=str, default=None, help="workflow")
+    for flag, kwargs in extra:
+        parser.add_argument(flag, **kwargs)
+    return parser

--- a/jenkins/scripts/comparison/make_compare_data.py
+++ b/jenkins/scripts/comparison/make_compare_data.py
@@ -1,37 +1,68 @@
-import yaml
+"""Run a comparison shell (N03 timeDiff or N04 compareProducts) for the given
+release vs the previous release in the data tree, write step{N}.txt under
+<release>/<arch>/<workflow>/.
+
+Inline shell then xrdcopies the <release>/ tree to either TimeDiff/ or CompProd/.
+"""
+
+from __future__ import annotations
+
 import os
 import sys
 
-data_path = '/eos/cms/store/user/cmsbuild/profiling/data/'
-cmssw = os.listdir(data_path)
-cmssw.sort(key = lambda x: (x.split('_')[1:4],10-len(x.split('_')),len(x)))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import _common
 
-import argparse
-parser = argparse.ArgumentParser()
-parser.add_argument("--operator", type=str, help="operator", default=None)
-parser.add_argument("--workflow", type=str, help="workflow", default=None)
-parser.add_argument("--release", type=str, help="CMSSW release", default=None)
-args = parser.parse_args()
 
-new = args.release
-old = cmssw[cmssw.index(new)-1]
-new_architecture = os.listdir(os.path.join(data_path,new))[0]
-old_architecture = os.listdir(os.path.join(data_path,old))[0]
-workflow = args.workflow
-operator = args.operator
+def release_sort_key(release: str) -> tuple:
+    """Sort releases by major.minor.patch tokens, mirroring the original."""
+    return (release.split("_")[1:4], 10 - len(release.split("_")), len(release))
 
-result_path = "{0}/{1}/{2}/".format(new,new_architecture,workflow)
 
-for step in ['step3','step4','step5']:
-	
-	new_data = os.path.join(data_path,new,new_architecture,workflow,'{}_TimeMemoryInfo.log'.format(step))
-	old_data = os.path.join(data_path,old,old_architecture,workflow,'{}_TimeMemoryInfo.log'.format(step))
+def previous_release(data_path: str, release: str) -> str:
+    """The release immediately preceding `release` in the sorted data tree."""
+    releases = sorted(os.listdir(data_path), key=release_sort_key)
+    idx = releases.index(release)
+    return releases[idx - 1]
 
-	os.makedirs(result_path,exist_ok = True)
-	if os.path.isfile(new_data) and os.path.isfile(old_data):
-		os.system("source ./{8} {0}{2}/{3}/{6}/{7} {0}{4}/{5}/{6}/{7} > {1}{7}.txt".format(
-		data_path,result_path,
-		old,old_architecture,
-		new,new_architecture,
-		workflow,step,operator))
 
+def main() -> None:
+    parser = _common.make_parser(
+        "Run a comparison operator (N03/N04 shell) and emit step{N}.txt files.",
+        need=("release", "workflow"),
+        extra=[("--operator", dict(type=str, required=True,
+                                   help="comparison shell: N03_timeDiffFromReport.sh "
+                                        "or N04_compareProducts.sh"))],
+    )
+    args = parser.parse_args()
+
+    data_path = args.profile_data
+    new = args.release
+    old = previous_release(data_path, new)
+    workflow = args.workflow
+    operator = args.operator
+
+    new_arch = os.listdir(os.path.join(data_path, new))[0]
+    old_arch = os.listdir(os.path.join(data_path, old))[0]
+
+    out_root = os.path.join(new, new_arch, workflow)
+    os.makedirs(out_root, exist_ok=True)
+
+    for step in ("step3", "step4", "step5"):
+        new_log = _common.step_file(new, new_arch, workflow, step,
+                                    "_TimeMemoryInfo.log", base=data_path)
+        old_log = _common.step_file(old, old_arch, workflow, step,
+                                    "_TimeMemoryInfo.log", base=data_path)
+        if not (os.path.isfile(new_log) and os.path.isfile(old_log)):
+            continue
+
+        # The comparison shells (N03/N04) take basenames without suffix and
+        # add ".log" / ".root" themselves — match the historical contract.
+        old_base = _common.step_file(old, old_arch, workflow, step, "", base=data_path)
+        new_base = _common.step_file(new, new_arch, workflow, step, "", base=data_path)
+        out = os.path.join(out_root, f"{step}.txt")
+        os.system(f"source ./{operator} {old_base} {new_base} > {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/jenkins/scripts/draw_eventsize.py
+++ b/jenkins/scripts/draw_eventsize.py
@@ -1,93 +1,114 @@
+"""Plot per-event uncompressed/compressed size history.
+
+Two flavours per step:
+    Recent8EventSize_<workflow>_<step>.png  -- last 8 releases
+    EventsizeSummary_<vers>_<workflow>_<step>.png  -- only releases in <vers>
+
+Inline shell xrdcopies `*.png` from cwd to circles/web/hist/.
+
+Usage:
+    python3 draw_eventsize.py <RELEASE> <WORKFLOW>
+"""
+
+from __future__ import annotations
+
+import csv
 import os
 import sys
-import csv
+
 import matplotlib.pyplot as plt
-from matplotlib import rc
-from matplotlib import gridspec
-#import mplhep as hep
-
-version = str(os.sys.argv[1])
-spec = os.sys.argv[2]
-
-def main(version,spec,step,job):
-	X = [] # CMSSW Version
-	AUS = [] # Average Uncompressed Size
-	ACS = [] # Average Compressed Size
-	vers = version
-	vers = "_".join(vers.split("_")[1:3])
-	version = "_".join(version.split("_")[1:4])
-
-	with open('history_'+spec+'_'+step+'.csv','r') as hist:
-		rd = csv.reader(hist)
-		idx = 0
-		for l in rd:
-			X.append(l[0].replace("CMSSW_",""))
-			AUS.append(round(float(l[1]),1))
-			ACS.append(round(float(l[2]),1))
-	if job == 'A':
-		X = X[-8:]
-		AUS = AUS[-8:]
-		ACS = ACS[-8:]
-	elif job == 'B':
-		m = [i for i in range(len(X)) if str(version) in X[i]]
-		X = X[min(m):max(m)+1]
-		AUS = AUS[min(m):max(m)+1]
-		ACS = ACS[min(m):max(m)+1]
-		print(X)
-
-	plt.rcParams["figure.figsize"] = (20,10)
-	plt.rc('font', size=20)     
-	plt.rc('axes', labelsize=20) 
-	plt.rc('xtick', labelsize=20)
-	plt.rc('ytick', labelsize=20) 
-	plt.rc('legend', fontsize=20) 
-	fig, ax1 = plt.subplots()
-	line1 = ax1.plot(X,AUS, '--bo',label ="Average Uncompressed Size ("+spec+")", color ='blue',linewidth=3,markersize=8)
-	for i, v in enumerate(X):
-		ax1.text(v, AUS[i], AUS[i],
-		     fontsize = 20,
-		     color='black',
-		     horizontalalignment='right',  # horizontalalignment (left, center, right)
-		     verticalalignment='bottom')    # verticalalignment (top, center, bottom)
-
-	ax2 = ax1.twinx()
-	line2 = ax2.plot(X,ACS, '--bo',label ="Average Compressed Size ("+spec+")", color ='green',linewidth=3,markersize=8)
-	for i, v in enumerate(X):
-		ax2.text(v, ACS[i], ACS[i],
-		     fontsize = 20,
-		     color='black',
-		     horizontalalignment='left',  # horizontalalignment (left, center, right)
-		     verticalalignment='top')    # verticalalignment (top, center, bottom)
-
-	ax1.set_xlabel("CMSSW Version", fontsize=25)
-	ax1.set_ylabel("Size/Event [kB]", fontsize=25)
-	ax2.set_ylabel("Size/Event [kB]", fontsize=25)
-	lines = line1 + line2
-	labels = [l.get_label() for l in lines]
-	ax1.legend(lines, labels)
-
-	if job == 'A':
-		plt.savefig("Recent8EventSize_"+spec+"_"+step+".png")
-		plt.close()
-	if job == 'B':
-		plt.savefig("EventsizeSummary_"+vers+"_"+spec+"_"+step+".png")
-		plt.close()
-		
-		
 
 
+def read_history(csv_path: str) -> tuple[list[str], list[float], list[float]]:
+    versions, uncom, compr = [], [], []
+    with open(csv_path) as f:
+        for row in csv.reader(f):
+            versions.append(row[0].replace("CMSSW_", ""))
+            uncom.append(round(float(row[1]), 1))
+            compr.append(round(float(row[2]), 1))
+    return versions, uncom, compr
 
-### I/O check
-if len(os.sys.argv) < 2:
-        print("Missing Input file!!")
-        exit(-9)
+
+def slice_for_job(job: str, version_window: str,
+                  versions: list[str], uncom: list[float], compr: list[float]
+                  ) -> tuple[list[str], list[float], list[float]]:
+    if job == "A":
+        return versions[-8:], uncom[-8:], compr[-8:]
+    if job == "B":
+        idxs = [i for i, v in enumerate(versions) if version_window in v]
+        if not idxs:
+            return [], [], []
+        lo, hi = min(idxs), max(idxs) + 1
+        return versions[lo:hi], uncom[lo:hi], compr[lo:hi]
+    raise ValueError(job)
 
 
-version
-### main code
-if __name__=="__main__":
+def render(version_short: str, workflow: str, step: str, job: str,
+           versions: list[str], uncom: list[float], compr: list[float]) -> None:
+    plt.rcParams["figure.figsize"] = (20, 10)
+    plt.rc("font", size=20)
+    plt.rc("axes", labelsize=20)
+    plt.rc("xtick", labelsize=20)
+    plt.rc("ytick", labelsize=20)
+    plt.rc("legend", fontsize=20)
 
-	for step in ['step3','step4','step5']:
-		if os.path.isfile("history_{0}_{1}.csv".format(spec,step)):
-			main(version,spec,step,'A')
-			main(version,spec,step,'B')
+    fig, ax1 = plt.subplots()
+    line1 = ax1.plot(versions, uncom, "--bo",
+                     label=f"Average Uncompressed Size ({workflow})",
+                     color="blue", linewidth=3, markersize=8)
+    for x, y in zip(versions, uncom):
+        ax1.text(x, y, y, fontsize=20, color="black",
+                 horizontalalignment="right", verticalalignment="bottom")
+
+    ax2 = ax1.twinx()
+    line2 = ax2.plot(versions, compr, "--bo",
+                     label=f"Average Compressed Size ({workflow})",
+                     color="green", linewidth=3, markersize=8)
+    for x, y in zip(versions, compr):
+        ax2.text(x, y, y, fontsize=20, color="black",
+                 horizontalalignment="left", verticalalignment="top")
+
+    ax1.set_xlabel("CMSSW Version", fontsize=25)
+    ax1.set_ylabel("Size/Event [kB]", fontsize=25)
+    ax2.set_ylabel("Size/Event [kB]", fontsize=25)
+    lines = line1 + line2
+    ax1.legend(lines, [l.get_label() for l in lines])
+
+    if job == "A":
+        plt.savefig(f"Recent8EventSize_{workflow}_{step}.png")
+    else:  # job == "B"
+        plt.savefig(f"EventsizeSummary_{version_short}_{workflow}_{step}.png")
+    plt.close()
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print("Usage: draw_eventsize.py <RELEASE> <WORKFLOW>")
+        sys.exit(-9)
+
+    release = sys.argv[1]
+    workflow = sys.argv[2]
+
+    # version_short: "16_0" (used in output filename "EventsizeSummary_16_0_...")
+    version_short = "_".join(release.split("_")[1:3])
+    # version_window: "16_0_4" — used to filter releases inside the same patch series
+    version_window = "_".join(release.split("_")[1:4])
+
+    for step in ("step3", "step4", "step5"):
+        csv_path = f"history_{workflow}_{step}.csv"
+        if not os.path.isfile(csv_path):
+            continue
+
+        versions, uncom, compr = read_history(csv_path)
+        if not versions:
+            continue
+
+        for job in ("A", "B"):
+            v, u, c = slice_for_job(job, version_window, versions, uncom, compr)
+            if not v:
+                continue
+            render(version_short, workflow, step, job, v, u, c)
+
+
+if __name__ == "__main__":
+    main()

--- a/jenkins/scripts/eventsize_batch.py
+++ b/jenkins/scripts/eventsize_batch.py
@@ -1,22 +1,32 @@
+"""Run edmEventSize on each step's .root and convert to JSON.
+
+Output filename: <release>_<arch>_<step>_eventSize.json (produced by
+make_eventsize-json.py). Inline shell xrdcopies `*.json` from cwd to
+results/circles/web/data/.
+"""
+
+from __future__ import annotations
+
 import os
 import sys
 
-DATA_DIR = '/eos/cms/store/user/cmsbuild/profiling/data'
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _common
 
-import argparse
-parser = argparse.ArgumentParser()
-parser.add_argument("--profile-data", type=str, default=DATA_DIR, help="profiling data location")
-parser.add_argument("--release", type=str, help="CMSSW release", default=None)
-parser.add_argument("--architecture", type=str, help="architecture for release", default=None)
-parser.add_argument("--workflow", type=str, help="workflow", default=None)
-args = parser.parse_args()
+JSON_BUILDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "make_eventsize-json.py")
 
-release = args.release
-architecture = args.architecture
-workflow = args.workflow
 
-for step in ['step3','step4','step5']:
-	file_path="{}/{}/{}/{}/{}.root".format(DATA_DIR,release,architecture,workflow,step)
-	if os.path.isfile(file_path):
-		os.system("edmEventSize -o eventSize_{0}.txt -F {1}".format(step,file_path))
-		os.system("python3 make_eventsize-json.py eventSize_{}.txt".format(step))
+def main() -> None:
+    args = _common.make_parser("edmEventSize batch + JSON conversion").parse_args()
+    release, arch, wf = args.release, args.architecture, args.workflow
+
+    for step in ("step3", "step4", "step5"):
+        root_path = _common.step_file(release, arch, wf, step, ".root", base=args.profile_data)
+        if not os.path.isfile(root_path):
+            continue
+        os.system(f"edmEventSize -o eventSize_{step}.txt -F {root_path}")
+        os.system(f"python3 {JSON_BUILDER} eventSize_{step}.txt")
+
+
+if __name__ == "__main__":
+    main()

--- a/jenkins/scripts/make_RES.py
+++ b/jenkins/scripts/make_RES.py
@@ -1,32 +1,60 @@
+"""Run igprof-analyse on each step's CPU/MEM .gz and write .res files.
+
+Outputs go directly under RESULT_PATH/RES/<release>/<arch>/<workflow>/ via the
+shared NFS/EOS mount (the inline shell does NOT xrdcopy these — see config.xml
+section "make_RES.py" — so they must land there in-place).
+
+Output naming preserved verbatim:
+    step{N}_cpu.res
+    step{N}_mem_<igprof-suffix>.res    (suffix = "1" / "200" / "399" / "")
+"""
+
+from __future__ import annotations
+
 import os
 import sys
 
-DATA_DIR = '/eos/cms/store/user/cmsbuild/profiling/data'
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _common
 
-import argparse
-parser = argparse.ArgumentParser()
-parser.add_argument("--profile-data", type=str, default=DATA_DIR, help="profiling data location")
-parser.add_argument("--release", type=str, help="CMSSW release", default=None)
-parser.add_argument("--architecture", type=str, help="architecture for release", default=None)
-parser.add_argument("--workflow", type=str, help="workflow", default=None)
-args = parser.parse_args()
+MAKE_RES_SH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "make_res.sh")
 
-release = args.release
-architecture = args.architecture
-workflow = args.workflow
 
-for step in ['step3','step4','step5']:
-	data_dir = "{0}/{1}/{2}".format(release,architecture,workflow)
-	gz_list = [x for x in os.listdir("{0}/{1}/{2}/{3}".format(DATA_DIR,release,architecture,workflow)) if "gz" in x and step in x]
-	if len(gz_list)==0:
-		continue
-	print(release,architecture,workflow,step)
-	for gz in gz_list:
-		if "CPU" in gz:
-			if os.path.isfile("/eos/project/c/cmsweb/www/reco-prof/results/RES/{0}/{1}_cpu.res".format(data_dir,step)):
-				continue
-			os.system("source ./make_res.sh 0 {0}/{1}/{2} /eos/project/c/cmsweb/www/reco-prof/results/RES/{1}/{3}_cpu.res".format(DATA_DIR,data_dir,gz,step))
-		elif "MEM" in gz:
-			if os.path.isfile("/eos/project/c/cmsweb/www/reco-prof/results/RES/{0}/{1}_mem_{2}.res".format(data_dir,step,gz.split(".")[1])):
-				continue
-			os.system("source ./make_res.sh 1 {0}/{1}/{2} /eos/project/c/cmsweb/www/reco-prof/results/RES/{1}/{3}_mem_{4}.res".format(DATA_DIR,data_dir,gz,step,gz.split(".")[1]))
+def igprof_suffix(gz_name: str) -> str:
+    """Extract the checkpoint suffix from a name like 'step3_igprofMEM.200.gz'."""
+    # gz_name = "step{N}_igprofMEM.<suffix>.gz" or "step{N}_igprofMEM.gz"
+    parts = gz_name.split(".")
+    return parts[1] if len(parts) >= 3 else ""
+
+
+def main() -> None:
+    args = _common.make_parser("igprof-analyse runner").parse_args()
+    release, arch, wf = args.release, args.architecture, args.workflow
+
+    src_root = _common.data_dir(release, arch, wf, base=args.profile_data)
+    out_root = _common.result_subdir("RES", release, arch, wf)
+    os.makedirs(out_root, exist_ok=True)
+
+    for step in ("step3", "step4", "step5"):
+        gz_files = [f for f in os.listdir(src_root) if f.endswith(".gz") and step in f]
+        if not gz_files:
+            continue
+        print(release, arch, wf, step)
+
+        for gz in gz_files:
+            src = os.path.join(src_root, gz)
+            if "CPU" in gz:
+                out = os.path.join(out_root, f"{step}_cpu.res")
+                if os.path.isfile(out):
+                    continue
+                os.system(f"source {MAKE_RES_SH} 0 {src} {out}")
+            elif "MEM" in gz:
+                suffix = igprof_suffix(gz)
+                out = os.path.join(out_root, f"{step}_mem_{suffix}.res")
+                if os.path.isfile(out):
+                    continue
+                os.system(f"source {MAKE_RES_SH} 1 {src} {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/jenkins/scripts/make_eventsize-json.py
+++ b/jenkins/scripts/make_eventsize-json.py
@@ -1,134 +1,116 @@
-import os
+"""Convert `edmEventSize` text output into JSON for the circles pie-chart UI.
+
+Input:  edmEventSize text file. First line carries the path to the .root file
+        (from which we recover release / arch / step). Second line is a
+        column header, skipped. Subsequent lines are either:
+
+            <collection>:<branch>  (TYPE)            <uncomp>  <comp>
+        or:
+            <collection>:<sub_branch>                <uncomp>  <comp>
+
+        The first form starts a new module; the second is folded into the
+        running module's totals.
+
+Output: <release>_<arch>_<step>_eventSize.json with the structure expected
+        by results/circles/web/eventsize.php.
+
+Sizes are stored in kB and multiplied by nEvents (the per-event size
+already comes through the file: edmEventSize prints byte-per-event values,
+so multiplication restores the integral that the PHP UI expects).
+"""
+
+from __future__ import annotations
+
 import json
-import csv
-#import string
-
-def findVersion(firstline):
-	for idx in range(len(firstline)):
-		if 'CMSSW' in firstline[idx]:
-			flist = firstline[idx].split("/")
-			for seq in range(len(flist)):
-				if 'CMSSW' in flist[seq]:
-					version = flist[seq]
-					spec = flist[seq+2]
-					step = flist[seq+3].replace(".root","")
-	return version, spec, step
+import os
+import sys
 
 
-def main(filename):
-
-	## Variables Initialization
-	modules = []
-	resources = []
-	total = {}
-	output = {}
-	cnt = 0
-	total_uncom = 0.0
-	total_compr = 0.0
-
-	with open(filename) as f:
-		## lineloop
-		for l in f:
-			## avoiding lastline
-			try:		
-				vl = l.split(" ")
-				#print(vl)
-
-				## nEvents
-				if cnt == 0:
-					nEvents = vl[-1].replace("\n","")
-					version, spec, step = findVersion(vl)
-					cnt = cnt + 1
-					continue
-
-				if cnt == 1:
-					cnt = cnt - 2
-					continue
-
-				## Normalline discriminator
-				disc = vl[1]
-				modulesDict = {}
-				#print(disc)
-
-				## Mainline clusters
-				if '(' in disc:
-					## Preprocessing
-					collections = vl[0].split(":")
-					collection = collections[0]
-					#cl = collections[0]
-					cl = vl[1]
-					size_uncom = vl[-2]
-					size_compr = vl[-1].replace("\n","")
-					cl = cl.replace("(","").replace(")","")
-		
-					## Making dictionary
-					modulesDict['events'] = int(nEvents)
-					modulesDict['label'] = collection
-
-					### SIZE * nEvents (because of overlapping division) / kB unit
-					modulesDict['size_uncom'] = (float(size_uncom)/1024.)*int(nEvents)
-					modulesDict['size_compr'] = (float(size_compr)/1024.)*int(nEvents)
-					modulesDict['type'] = cl
-					print(modulesDict)
-
-					## Sum for total
-					total_uncom = total_uncom + (float(size_uncom)/1024.)*int(nEvents)
-					total_compr = total_compr + (float(size_compr)/1024.)*int(nEvents)
-
-				else:
-					size_uncom = vl[-2]
-					size_compr = vl[-1].replace("\n","")
-
-					## Sum for total
-					total_uncom = total_uncom + (float(size_uncom)/1024.)*int(nEvents)
-					total_compr = total_compr + (float(size_compr)/1024.)*int(nEvents)
-
-				if len(modulesDict) != 0:
-					modules.append(modulesDict)
-
-			except:
-				break
-
-		## make resources
-		size_uncomDict = {}
-		size_comprDict = {}
-		size_uncomDict['size_uncom'] = "Average Uncompressed Size"
-		size_comprDict['size_compr'] = "Average Compressed Size"
-		resources.append(size_uncomDict)
-		resources.append(size_comprDict)
-
-		## make total
-		total['events'] = nEvents
-		total['label'] = "step3_eventsize"
-		total['size_uncom'] = total_uncom
-		total['size_compr'] = total_compr
-		total['type'] = "job"
-
-		## merge modules
-		output['modules'] = modules
-		output['resources'] = resources
-		output['total'] = total
-
-		## Output
-		fileModules = open(version+"_"+spec+"_"+step+"_eventSize.json","w")
-		
-		## dump and save
-		json.dump(output, fileModules, ensure_ascii=False, indent=4 )
-
-### I/O check
-if len(os.sys.argv) < 2:
-	print("Missing Input file!!")
-	exit(-9)
+def find_release_spec_step(first_line_tokens: list[str]) -> tuple[str, str, str]:
+    """Recover (release, arch, step) from the first-line CMSSW path token."""
+    for tok in first_line_tokens:
+        if "CMSSW" not in tok:
+            continue
+        parts = tok.split("/")
+        for i, p in enumerate(parts):
+            if "CMSSW" in p:
+                release = p
+                arch = parts[i + 2]
+                step = parts[i + 3].replace(".root", "")
+                return release, arch, step
+    raise ValueError("no CMSSW path token found in first line")
 
 
-### define I/O
-filename = os.sys.argv[1]
-#output = os.sys.argv[2]
+def main(filename: str) -> None:
+    modules: list[dict] = []
+    total_uncom = 0.0
+    total_compr = 0.0
+    n_events = 0
+    release = arch = step = ""
+
+    with open(filename) as f:
+        for line_idx, line in enumerate(f):
+            tokens = line.split(" ")
+
+            # Line 0: "...nEvents N" — last token is the event count.
+            if line_idx == 0:
+                n_events = int(tokens[-1].replace("\n", ""))
+                release, arch, step = find_release_spec_step(tokens)
+                continue
+            # Line 1: column header.
+            if line_idx == 1:
+                continue
+
+            # Defensive: trailing blank lines or short lines from edmEventSize.
+            try:
+                disc = tokens[1]
+                size_uncom = float(tokens[-2])
+                size_compr = float(tokens[-1].replace("\n", ""))
+            except (IndexError, ValueError):
+                break
+
+            uncom_kb = (size_uncom / 1024.0) * n_events
+            compr_kb = (size_compr / 1024.0) * n_events
+
+            if "(" in disc:
+                # Top-level module line: "collection:branch  (TYPE)  uncom  comp"
+                collection = tokens[0].split(":")[0]
+                type_label = disc.replace("(", "").replace(")", "")
+                modules.append({
+                    "events": n_events,
+                    "label": collection,
+                    "size_uncom": uncom_kb,
+                    "size_compr": compr_kb,
+                    "type": type_label,
+                })
+                print(modules[-1])
+
+            total_uncom += uncom_kb
+            total_compr += compr_kb
+
+    output = {
+        "modules": modules,
+        # Resource labels embedded for the circles UI's resource picker.
+        "resources": [
+            {"size_uncom": "Average Uncompressed Size"},
+            {"size_compr": "Average Compressed Size"},
+        ],
+        "total": {
+            "events": str(n_events),
+            "label": "step3_eventsize",   # historical literal — UI keys off this
+            "size_uncom": total_uncom,
+            "size_compr": total_compr,
+            "type": "job",
+        },
+    }
+
+    out_name = f"{release}_{arch}_{step}_eventSize.json"
+    with open(out_name, "w") as fout:
+        json.dump(output, fout, ensure_ascii=False, indent=4)
 
 
-### main code
-if __name__=="__main__":
-	main(filename)
-
-### EOF
-
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Missing Input file!!")
+        sys.exit(-9)
+    main(sys.argv[1])

--- a/jenkins/scripts/make_eventsize_hist.py
+++ b/jenkins/scripts/make_eventsize_hist.py
@@ -1,45 +1,60 @@
-import sys
-import os
-import yaml
+"""Build per-step history CSV across releases for one workflow.
+
+Reads JSONs already published under RESULT_PATH/circles/web/data/ (made by
+make_eventsize-json.py earlier) and emits history_<workflow>_<step>.csv with
+one row per release: <release>,<avg_uncom_kB>,<avg_comp_kB>.
+
+draw_eventsize.py consumes this CSV next.
+"""
+
+from __future__ import annotations
+
 import json
-import shutil
+import os
+import sys
 
-import argparse
-parser = argparse.ArgumentParser()
-parser.add_argument("--workflow", type=str, help="workflow", default=None)
-args = parser.parse_args()
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _common
 
-workflow = args.workflow
 
-data_path = '/eos/cms/store/user/cmsbuild/profiling/data/'
-result_path = '/eos/project/c/cmsweb/www/reco-prof/results/circles/web/data/'
+def release_sort_key(release: str) -> tuple:
+    """Mirror the original sort: by major.minor.patch tokens then by name length."""
+    return (release.split("_")[1:4], 10 - len(release.split("_")), len(release))
 
-cmssw_list = os.listdir(data_path)
-cmssw_list.sort(key = lambda x: (x.split('_')[1:4],10-len(x.split('_')),len(x)))
 
-steps = ['step3','step4','step5']
-#------------------------------------------------------------------
-for step in steps:
+def main() -> None:
+    args = _common.make_parser("Event-size release history CSV", need=("workflow",)).parse_args()
+    workflow = args.workflow
+    if not workflow:
+        sys.exit("--workflow is required")
 
-	csv = open("history_{0}.csv".format(step),'w')
+    data_root = args.profile_data
+    json_root = _common.result_subdir("circles", "web", "data")
 
-	for cmssw in cmssw_list:
+    releases = sorted(os.listdir(data_root), key=release_sort_key)
 
-		gcc = os.listdir(data_path + cmssw)[0]
-		TMI = '{0}{1}/{2}/{3}/{4}_TimeMemoryInfo.log'.format(data_path,cmssw,gcc,workflow,step)
-		wf = workflow
+    for step in ("step3", "step4", "step5"):
+        out = f"history_{workflow}_{step}.csv"
+        rows: list[str] = []
 
-		if os.path.isfile('{0}/{1}_{2}_{3}_eventSize.json'.format(result_path,cmssw,workflow,step)):
-			with open('{0}/{1}_{2}_{3}_eventSize.json'.format(result_path,cmssw,workflow,step)) as f:
-				json_data=json.load(f)
-				events = json_data['total']['events']
-				uncom = json_data['total']['size_uncom']/int(events)
-				compr = json_data['total']['size_compr']/int(events)
-				csv.write('{0},{1},{2}\n'.format(cmssw,uncom,compr))
+        for release in releases:
+            json_path = os.path.join(json_root, f"{release}_{workflow}_{step}_eventSize.json")
+            if not os.path.isfile(json_path):
+                continue
+            with open(json_path) as f:
+                data = json.load(f)
+            events = int(data["total"]["events"])
+            if events == 0:
+                continue
+            uncom = data["total"]["size_uncom"] / events
+            compr = data["total"]["size_compr"] / events
+            rows.append(f"{release},{uncom},{compr}\n")
 
-	csv.close()
-	shutil.move('history_{0}.csv'.format(step),'history_{0}_{1}.csv'.format(workflow,step))
+        if not rows:
+            continue
+        with open(out, "w") as f:
+            f.writelines(rows)
 
-	if len(open('history_{0}_{1}.csv'.format(workflow,step)).readlines()) == 0:
-		os.remove('history_{0}_{1}.csv'.format(workflow,step))
 
+if __name__ == "__main__":
+    main()

--- a/jenkins/scripts/make_webpage.py
+++ b/jenkins/scripts/make_webpage.py
@@ -1,44 +1,63 @@
-"""Render index.html for cms-reco-profiling.web.cern.ch.
+"""Generate index.html for cms-reco-profiling.web.cern.ch.
 
-Reads everything that previous pipeline stages staged under RESULT_PATH and
-emits a single static HTML document on stdout. The inline shell redirects
-the output to index.html and xrdcopies to <webroot>/web/.
+Strategy: instead of pre-rendering every link server-side, this script walks
+the EOS results tree once, builds a JSON manifest of available data, and
+emits an HTML page that embeds the manifest and renders it client-side.
 
-Output preserves the historical structure: per-version <details> sections,
-followed by per-workflow nested lists with links to summary plots, RES files,
-igprof navigators, comparison previews, circles pie charts, etc.
+A broken results .txt no longer kills the entire page. Each release ×
+workflow × step cell is built inside its own try/except, so the worst case
+is "this one cell has no preview" rather than "all 50 releases blank because
+one TimeDiff trailer was truncated".
+
+The inline shell still calls `python3 make_webpage.py <RELEASE> > index.html`
+exactly as before; only the *contents* of index.html change.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import sys
+from typing import Any
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import _common
 
 
-# ── Per-step labelling ───────────────────────────────────────────────────────
-# step token  -> (workflow-section title token, summary-plot label, eventsize-plot label, recent8 label)
+# Step → human-readable labels used in the rendered page.
+# `long`  : section heading inside a workflow's <ul>
+# `short` : bracketed link label, e.g. "[Short Summary Time and Memory(AOD)]"
+# `plot`  : descriptive token used in the family-level summary plot heading
 STEP_META = {
-    "step2": ("step2_RAW(DIGI)",     "RAW_DIGI",     "RAW_DIGI",     "RAW_DIGI"),
-    "step3": ("step3_AOD(RECO)",     "RECO_AOD",     "RECO_AOD",     "RECO_AOD"),
-    "step4": ("step4_MiniAOD(PAT)",  "PAT_MiniAOD",  "PAT_MiniAOD",  "PAT_MiniAOD"),
-    "step5": ("step5_NanoAOD",       "NanoAOD",      "NanoAOD",      "NanoAOD"),
-}
-# Short label used in the summary-plot and event-size [bracketed link text].
-SHORT_LABEL = {
-    "step2": ("DIGI", "RAW"),
-    "step3": ("AOD",  "AOD"),
-    "step4": ("MINIAOD", "MINIAOD"),
-    "step5": ("NANOAOD", "NANOAOD"),
+    "step2": {"long": "step2_RAW(DIGI)",    "short": "DIGI",    "plot": "RAW_DIGI"},
+    "step3": {"long": "step3_AOD(RECO)",    "short": "AOD",     "plot": "RECO_AOD"},
+    "step4": {"long": "step4_MiniAOD(PAT)", "short": "MINIAOD", "plot": "PAT_MiniAOD"},
+    "step5": {"long": "step5_NanoAOD",      "short": "NANOAOD", "plot": "NanoAOD"},
 }
 
 
-def out(s: str = "") -> None:
-    print(s)
+# ── Filesystem helpers (each returns "" / [] / None on missing/unreadable) ───
+def safe_listdir(path: str) -> list[str]:
+    try:
+        return sorted(os.listdir(path))
+    except OSError:
+        return []
 
 
+def safe_last_tokens(path: str, min_count: int) -> list[str] | None:
+    """Read last line of `path`, split on whitespace; return tokens iff >= min_count."""
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except OSError:
+        return None
+    if not lines:
+        return None
+    toks = lines[-1].split()
+    return toks if len(toks) >= min_count else None
+
+
+# ── Sorting & family helpers ────────────────────────────────────────────────
 def release_sort_key(release: str) -> tuple:
     return (release.split("_")[1:4], 10 - len(release.split("_")), len(release))
 
@@ -47,231 +66,424 @@ def family_of(release: str) -> str:
     return "_".join(release.split("_")[:3])
 
 
-# ── Section emitters ─────────────────────────────────────────────────────────
-def emit_summary_plot_links(family: str, plots: list[str]) -> None:
-    """The 'Summary of <family>_X(<type>)(<wf>) [Short Summary ...]' block."""
-    for plot in plots:
-        if family not in plot:
-            continue
-        for step, (_, plot_label, _, _) in STEP_META.items():
-            if step not in plot:
-                continue
-            wf = ".".join(plot.split("_")[4].split(".")[0:1])
-            short = SHORT_LABEL[step][0]
-            out('<span style=" font: normal bold 1.0em Georgia, serif ; color: navy;">')
-            out(f'\t<h3>Summary of {family}_X({plot_label})({wf}) '
-                f'<font size="2em"><a target=\'_blank\' '
-                f'href="{_common.RESULT_ADDRESS}summary_plot_html/{plot}" '
-                f'title="shortSummary">[Short Summary Time and Memory({short})]</a></font></h3>')
-            break
+# ── Manifest builders ───────────────────────────────────────────────────────
+def build_step_cell(release: str, gcc: str, workflow: str, step: str) -> dict:
+    """Per-step manifest cell. Each side-effect is isolated."""
+    cell: dict[str, Any] = {}
 
-
-def emit_eventsize_plot_links(family_short: str, plots: list[str]) -> None:
-    """family_short: e.g. '14_0' (without 'CMSSW_' prefix)."""
-    for plot in plots:
-        if family_short not in plot:
-            continue
-        for step, (_, _, label, _) in STEP_META.items():
-            if step not in plot:
-                continue
-            wf = plot.split("_")[3].split(".")[0]
-            short = SHORT_LABEL[step][1]
-            out('<span style=" font: normal bold 1.0em Georgia, serif ; color: navy;">')
-            out(f'        <h3>EventSize Summary({label})({wf}) '
-                f'<font size="2em"><a target=\'_blank\' '
-                f'href="{_common.RESULT_ADDRESS}circles/web/hist/{plot}" '
-                f'title="shortSummary">[EventSize Summary({short})]</a></font></h3>')
-            break
-
-
-def emit_recent_plot_links(plots: list[str]) -> None:
-    for plot in plots:
-        if "Recent" not in plot:
-            continue
-        for step, (_, _, _, label) in STEP_META.items():
-            if step not in plot:
-                continue
-            wf = plot.split("_")[1].split(".")[0]
-            short = SHORT_LABEL[step][1]
-            out('<span style=" font: normal bold 1.0em Georgia, serif ; color: navy;">')
-            out(f'        <h3>Recent8 Summary({label})({wf}) '
-                f'<font size="2em"><a target=\'_blank\' '
-                f'href="{_common.RESULT_ADDRESS}circles/web/hist/{plot}" '
-                f'title="shortSummary">[Recent8 Summary({short})]</a></font></h3>')
-            break
-
-
-def emit_step_links(release: str, gcc: str, workflow: str, step: str, family: str) -> None:
-    """All per-step links inside a workflow's <ul> (the deepest level)."""
-    addr = _common.RESULT_ADDRESS
-    from_data = f"{release}/{gcc}/{workflow}/"
-    from_cgi = f"{release}/{workflow}/{step}/"
-
-    out(f'\n\t\t\t<li><strong>{STEP_META[step][0]}</strong>')
-    out('\n\t\t\t\t<ul>')
-    out(f'\n\t\t\t\t<li>\n\t\t\t\t<a href="{addr}Time_Mem_Summary/{from_data}{step}.txt" '
-        f'title="getTimeMemSummary">[getTimeMemSummary]</a>')
-    out(f'\n\t\t\t\t<a href="{addr}Time_Mem_Summary/{from_data}memory_report_{step}.txt" '
-        f'title="memory_report">[memory_report]</a>')
-
-    # IgProf navigator + .res txt links.
-    cgi_dir = f"/eos/project/c/cmsweb/www/reco-prof/cgi-bin/data/releases/{from_cgi}"
+    # IgProf navigator + .res files (the cgi-bin dir is populated by main.py --igprof)
+    cgi_dir = (f"/eos/project/c/cmsweb/www/reco-prof/cgi-bin/data/releases/"
+               f"{release}/{workflow}/{step}")
     if os.path.isdir(cgi_dir):
-        res_dir = _common.result_subdir("RES", release, gcc, workflow)
-        if os.path.isdir(res_dir):
-            for res in (r for r in os.listdir(res_dir) if step in r):
-                if "cpu" in res:
-                    cgi_bin, ig_number = "cpu_endjob", ""
-                else:
+        cell["has_igprof_navigator"] = True
+        igprof = []
+        for res in safe_listdir(_common.result_subdir("RES", release, gcc, workflow)):
+            if step not in res:
+                continue
+            if "cpu" in res:
+                igprof.append({
+                    "profiler": "cpu", "ig_number": "",
+                    "cgi_bin": "cpu_endjob", "res": res,
+                })
+            elif "mem" in res:
+                try:
                     snap = res.split("_")[2].split(".")[0]
-                    cgi_bin, ig_number = f"mem_live.{snap}", snap
-                profiler = res.split("_")[1].split(".")[0]
-                out(f'\n\t\t\t<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/'
-                    f'cgi-bin/igprof-navigator/releases/{from_cgi}{cgi_bin}" '
-                    f'title="{profiler} time check">[{profiler} Profiler igprof{ig_number}]</a>'
-                    f'<a href="{addr}RES/{from_data}{res}" title="txtLink">[txtLink]</a>')
+                except IndexError:
+                    continue
+                igprof.append({
+                    "profiler": "mem", "ig_number": snap,
+                    "cgi_bin": f"mem_live.{snap}", "res": res,
+                })
+        cell["igprof"] = igprof
 
-    # Comparison block (TimeDiff + CompProd preview spans).
-    timediff_path = _common.result_subdir("TimeDiff", release, gcc, workflow, f"{step}.txt")
-    compprod_path = _common.result_subdir("CompProd", release, gcc, workflow, f"{step}.txt")
-    has_timediff = os.path.isfile(timediff_path)
-    has_compprod = os.path.isfile(compprod_path)
+    # TimeDiff trailer preview ("Job total: X s/ev ==> Y s/ev") — toks[2], toks[5]
+    tp = _common.result_subdir("TimeDiff", release, gcc, workflow, f"{step}.txt")
+    if os.path.isfile(tp):
+        cell["has_timediff"] = True
+        toks = safe_last_tokens(tp, 6)
+        if toks:
+            cell["timediff_preview"] = {"old": toks[2], "new": toks[5]}
 
-    if has_timediff or has_compprod:
-        out('\n\t\t\t<li>Comparison :\n\t\t\t<ul>')
+    # CompProd trailer preview ("oldSize newSize ...") — toks[1], toks[2]
+    cp = _common.result_subdir("CompProd", release, gcc, workflow, f"{step}.txt")
+    if os.path.isfile(cp):
+        cell["has_compprod"] = True
+        toks = safe_last_tokens(cp, 3)
+        if toks:
+            cell["compprod_preview"] = {"old": toks[1], "new": toks[2]}
 
-    if has_timediff:
-        with open(timediff_path) as f:
-            last = f.readlines()[-1]
-        toks = last.split()
-        out(f'\n\t\t\t\t<li>\n\t\t\t\t<a href="{addr}TimeDiff/{from_data}{step}.txt" '
-            f'title="TimeDiff">[TimeDiff]</a>'
-            f'<span style=" font: Arial; font-size: small; color: green;"> '
-            f'preview: {toks[2]} s/ev ==> {toks[5]} s/ev </span>\n\t\t\t\t</li>')
+    # IgProf comparison HTMLs (currently usually empty — those steps are
+    # commented out in the inline shell, but render survives if dir is filled)
+    pages = safe_listdir(_common.result_subdir("comp_igprof", "html", release, workflow, step))
+    if pages:
+        cig = []
+        for p in pages:
+            if "cpu" in p:
+                label = "cpu"
+            else:
+                parts = p.split("_")
+                snap = parts[1].split(".")[1] if len(parts) >= 2 and "." in parts[1] else "?"
+                label = f"mem.{snap}"
+            cig.append({"file": p, "label": label})
+        cell["compigprof"] = cig
 
-    if has_compprod:
-        with open(compprod_path) as f:
-            last = f.readlines()[-1]
-        toks = last.split()
-        out(f'\n\t\t\t\t<li>\n\t\t\t\t<a href="{addr}/CompProd/{from_data}{step}.txt" '
-            f'title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a>'
-            f'<span style=" font: Arial; font-size: small; color: red;"> '
-            f'preview: {toks[1]} ==> {toks[2]} </span>\n\t\t\t\t</li>')
+    # EventSize circle availability
+    json_path = _common.result_subdir(
+        "circles", "web", "data",
+        f"{release}_{workflow}_{step}_eventSize.json",
+    )
+    if os.path.isfile(json_path):
+        cell["has_eventsize_circle"] = True
 
-    if has_timediff or has_compprod:
-        out('\n\t\t\t</ul>')
+    return cell
 
-    # IgProf comparison HTMLs (currently unpopulated — those steps are
-    # commented out in the inline shell, but the rendering survives in case
-    # the directory is filled out-of-band).
-    igprof_dir = _common.result_subdir("comp_igprof", "html", from_cgi)
-    if os.path.isdir(igprof_dir):
-        pages = os.listdir(igprof_dir)
-        if pages:
-            out('\n\t\t\t<li>Igprof comparison :\n\t\t\t<ul>')
-            for page in pages:
-                if "cpu" in page:
-                    label = "cpu"
-                else:
-                    label = "mem." + page.split("_")[1].split(".")[1]
-                title = page.split("_")[0]
-                out(f'\n\t\t\t<li>\n\t\t\t<a href="{addr}comp_igprof/html/{from_cgi}{page}" '
-                    f'title="{title} compare">[{label} compare]</a>\n\t\t\t</li>')
-            out('\n\t\t\t</ul>')
 
-    # Circle pie chart + EventSize circle (skipped for the deprecated CMSSW_11_0
-    # branch and for workflow 136.889).
-    if family != "CMSSW_11_0" and workflow != "136.889":
-        circle_dataset = f"{release}%2F{gcc}%2F{workflow}%2F{step}_circles"
-        out('\n\t\t\t<li>Circle (Pie chart) :\n\t\t\t'
-            f'<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/'
-            f'circles/piechart.php?local=false&dataset={circle_dataset}'
-            f'&resource=time_real&colours=default&groups=reco_PhaseII_private&threshold=0" '
-            f'title="Circle">[Circle]</a>\n\t\t\t</li>')
+def build_workflow(release: str, gcc: str, workflow: str) -> dict:
+    wf: dict[str, Any] = {}
+    cmdlog_files = safe_listdir(_common.result_subdir("cmdlog", release, gcc, workflow))
+    wf["has_cmdlog"] = "cmdLog_profiling.txt" in cmdlog_files
 
-        eventsize_json = _common.result_subdir(
-            "circles", "web", "data",
-            f"{release}_{workflow}_{step}_eventSize.json")
-        if os.path.isfile(eventsize_json):
-            out('\n\t\t\t<li>EventSizeCircle (pie chart) :\n\t\t\t'
-                f'<a href="https://cms-reco-profiling.web.cern.ch/cms-reco-profiling/'
-                f'results/circles/web/eventsize.php?local=false&'
-                f'dataset={release}_{workflow}_{step}_eventSize&'
-                f'resource=size_uncom&colours=default&groups=Group_{step}_23Sep_v1'
-                f'&threshold=0" title="EventSize">[EventSize]</a>\n\t\t\t</li>')
+    tms_files = safe_listdir(_common.result_subdir("Time_Mem_Summary", release, gcc, workflow))
+    steps_seen = sorted({s.split(".")[0] for s in tms_files if s.split(".")[0] in STEP_META})
 
-    out("\t\t</ul>")
+    wf["steps"] = {}
+    for step in steps_seen:
+        try:
+            wf["steps"][step] = build_step_cell(release, gcc, workflow, step)
+        except Exception as e:
+            wf["steps"][step] = {"error": str(e)}
+    return wf
+
+
+def build_release(release: str) -> dict:
+    cmdlog_path = _common.result_subdir("cmdlog", release)
+    archs = safe_listdir(cmdlog_path)
+    rel: dict[str, Any] = {
+        "family": family_of(release),
+        "family_short": "_".join(release.split("_")[1:3]),
+        "gcc": archs[0] if archs else None,
+        "workflows": {},
+    }
+    if not rel["gcc"]:
+        return rel
+    for workflow in safe_listdir(os.path.join(cmdlog_path, rel["gcc"])):
+        try:
+            rel["workflows"][workflow] = build_workflow(release, rel["gcc"], workflow)
+        except Exception as e:
+            rel["workflows"][workflow] = {"error": str(e), "steps": {}}
+    return rel
+
+
+def group_summary_plots(plots: list[str], releases: dict) -> dict[str, list[str]]:
+    """Family-name → matching summary_plot_html filenames."""
+    families = sorted({r["family"] for r in releases.values() if r.get("family")})
+    out: dict[str, list[str]] = {f: [] for f in families}
+    for plot in plots:
+        for fam in families:
+            if fam in plot:
+                out[fam].append(plot)
+                break
+    return out
+
+
+def group_eventsize_plots(plots: list[str], releases: dict) -> dict[str, list[str]]:
+    """family_short ('16_0') → eventsize plot filenames."""
+    shorts = sorted({r["family_short"] for r in releases.values() if r.get("family_short")})
+    out: dict[str, list[str]] = {s: [] for s in shorts}
+    for plot in plots:
+        for s in shorts:
+            if s in plot:
+                out[s].append(plot)
+                break
+    return out
+
+
+def build_manifest(recent_release: str) -> dict:
+    cmdlog_path = _common.result_subdir("cmdlog")
+    cmssw_list = sorted(safe_listdir(cmdlog_path), key=release_sort_key)
+
+    releases: dict[str, dict] = {}
+    for cmssw in cmssw_list:
+        try:
+            releases[cmssw] = build_release(cmssw)
+        except Exception as e:
+            releases[cmssw] = {
+                "error": str(e), "workflows": {},
+                "family": family_of(cmssw), "family_short": "_".join(cmssw.split("_")[1:3]),
+                "gcc": None,
+            }
+
+    summary_html = safe_listdir(_common.result_subdir("summary_plot_html"))
+    hist = safe_listdir(_common.result_subdir("circles", "web", "hist"))
+
+    return {
+        "recent_release": recent_release,
+        "recent_family": family_of(recent_release),
+        "result_address": _common.RESULT_ADDRESS,
+        "step_meta": STEP_META,
+        "summary_plots_by_family": group_summary_plots(summary_html, releases),
+        "eventsize_plots_by_family_short": group_eventsize_plots(
+            [p for p in hist if "Eventsize" in p], releases),
+        "recent_plots": [p for p in hist if "Recent" in p],
+        "releases": releases,
+    }
+
+
+# ── HTML shell + client renderer ─────────────────────────────────────────────
+HTML_HEAD = """<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>CMS Reco Profiling</title>
+<style>
+  body { font-family: sans-serif; margin: 1em; line-height: 1.4; }
+  details > summary { font-size: 1.4em; font-weight: bold; cursor: pointer; padding: 0.2em 0; }
+  h2 { font-size: 1.3em; margin-top: 0.5em; }
+  h3 { font: normal bold 1.0em Georgia, serif; color: navy; margin: 0.3em 0; }
+  .preview-time { font-size: small; color: green; }
+  .preview-size { font-size: small; color: red; }
+  ul { padding-left: 1.5em; }
+  hr { margin: 0.8em 0; }
+  a { text-decoration: none; }
+  a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+<div id="root"></div>
+"""
+
+HTML_TAIL = """</body>
+</html>
+"""
+
+# Plain ES5 — no module loader, no external deps. Indentation isn't
+# semantically significant; raw string keeps backslashes intact.
+CLIENT_RENDER_JS = r"""
+const ADDR = MANIFEST.result_address;
+const STEP_META = MANIFEST.step_meta;
+const STEPS = ['step2', 'step3', 'step4', 'step5'];
+
+function el(tag, props) {
+  const e = document.createElement(tag);
+  if (props && props.html != null) e.innerHTML = props.html;
+  else if (props && props.text != null) e.textContent = props.text;
+  for (let i = 2; i < arguments.length; i++) {
+    const c = arguments[i];
+    if (c != null) e.appendChild(c);
+  }
+  return e;
+}
+
+function detectStep(name) {
+  for (let i = 0; i < STEPS.length; i++) if (name.indexOf(STEPS[i]) >= 0) return STEPS[i];
+  return null;
+}
+
+function emitFamilyHeader(details, family, familyShort) {
+  details.appendChild(el('h2', { html: family + '_X' }));
+
+  const sumPlots = MANIFEST.summary_plots_by_family[family] || [];
+  for (const p of sumPlots) {
+    const step = detectStep(p);
+    if (!step) continue;
+    const meta = STEP_META[step];
+    const wfPart = (p.split('_')[4] || '').split('.')[0];
+    details.appendChild(el('h3', { html:
+      'Summary of ' + family + '_X(' + meta.plot + ')(' + wfPart + ') ' +
+      '<a target="_blank" href="' + ADDR + 'summary_plot_html/' + p +
+      '">[Short Summary Time and Memory(' + meta.short + ')]</a>'
+    }));
+  }
+  details.appendChild(el('hr'));
+
+  const evPlots = MANIFEST.eventsize_plots_by_family_short[familyShort] || [];
+  for (const p of evPlots) {
+    const step = detectStep(p);
+    if (!step) continue;
+    const meta = STEP_META[step];
+    const parts = p.split('_');
+    const wfPart = (parts[3] || '').split('.')[0];
+    details.appendChild(el('h3', { html:
+      'EventSize Summary(' + meta.plot + ')(' + wfPart + ') ' +
+      '<a target="_blank" href="' + ADDR + 'circles/web/hist/' + p +
+      '">[EventSize Summary(' + meta.short + ')]</a>'
+    }));
+  }
+  details.appendChild(el('hr'));
+
+  if (family === MANIFEST.recent_family) {
+    for (const p of MANIFEST.recent_plots) {
+      const step = detectStep(p);
+      if (!step) continue;
+      const meta = STEP_META[step];
+      const wfPart = (p.split('_')[1] || '').split('.')[0];
+      details.appendChild(el('h3', { html:
+        'Recent8 Summary(' + meta.plot + ')(' + wfPart + ') ' +
+        '<a target="_blank" href="' + ADDR + 'circles/web/hist/' + p +
+        '">[Recent8 Summary(' + meta.short + ')]</a>'
+      }));
+    }
+    details.appendChild(el('hr'));
+  }
+}
+
+function emitStep(parentUl, release, gcc, workflow, step, cell) {
+  const meta = STEP_META[step];
+  const fromData = release + '/' + gcc + '/' + workflow + '/';
+  const fromCgi  = release + '/' + workflow + '/' + step + '/';
+
+  const stepLi = el('li', { html: '<strong>' + meta.long + '</strong>' });
+  const sub = el('ul');
+
+  sub.appendChild(el('li', { html:
+    '<a href="' + ADDR + 'Time_Mem_Summary/' + fromData + step + '.txt">[getTimeMemSummary]</a> ' +
+    '<a href="' + ADDR + 'Time_Mem_Summary/' + fromData + 'memory_report_' + step + '.txt">[memory_report]</a>'
+  }));
+
+  if (cell.has_igprof_navigator && cell.igprof) {
+    for (const ig of cell.igprof) {
+      sub.appendChild(el('li', { html:
+        '<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/' +
+          fromCgi + ig.cgi_bin + '">[' + ig.profiler + ' Profiler igprof' + ig.ig_number + ']</a>' +
+        '<a href="' + ADDR + 'RES/' + fromData + ig.res + '">[txtLink]</a>'
+      }));
+    }
+  }
+
+  if (cell.has_timediff || cell.has_compprod) {
+    const compLi = el('li', { html: 'Comparison :' });
+    const compUl = el('ul');
+    if (cell.has_timediff) {
+      const prev = cell.timediff_preview;
+      const span = prev
+        ? ' <span class="preview-time">preview: ' + prev.old + ' s/ev ==> ' + prev.new + ' s/ev</span>'
+        : '';
+      compUl.appendChild(el('li', { html:
+        '<a href="' + ADDR + 'TimeDiff/' + fromData + step + '.txt">[TimeDiff]</a>' + span
+      }));
+    }
+    if (cell.has_compprod) {
+      const prev = cell.compprod_preview;
+      const span = prev
+        ? ' <span class="preview-size">preview: ' + prev.old + ' ==> ' + prev.new + '</span>'
+        : '';
+      compUl.appendChild(el('li', { html:
+        '<a href="' + ADDR + '/CompProd/' + fromData + step + '.txt">[CompareOutProd (edmEventSize)]</a>' + span
+      }));
+    }
+    compLi.appendChild(compUl);
+    sub.appendChild(compLi);
+  }
+
+  if (cell.compigprof && cell.compigprof.length) {
+    const cigLi = el('li', { html: 'Igprof comparison :' });
+    const cigUl = el('ul');
+    for (const c of cell.compigprof) {
+      cigUl.appendChild(el('li', { html:
+        '<a href="' + ADDR + 'comp_igprof/html/' + fromCgi + c.file + '">[' + c.label + ' compare]</a>'
+      }));
+    }
+    cigLi.appendChild(cigUl);
+    sub.appendChild(cigLi);
+  }
+
+  // Circle / EventSize circle (suppressed for CMSSW_11_0 family or wf 136.889 — legacy gating)
+  const family = MANIFEST.releases[release].family;
+  if (family !== "CMSSW_11_0" && workflow !== "136.889") {
+    const ds = release + '%2F' + gcc + '%2F' + workflow + '%2F' + step + '_circles';
+    sub.appendChild(el('li', { html:
+      'Circle (Pie chart) : ' +
+      '<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/circles/piechart.php?' +
+      'local=false&dataset=' + ds +
+      '&resource=time_real&colours=default&groups=reco_PhaseII_private&threshold=0">[Circle]</a>'
+    }));
+    if (cell.has_eventsize_circle) {
+      sub.appendChild(el('li', { html:
+        'EventSizeCircle (pie chart) : ' +
+        '<a href="https://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/circles/web/eventsize.php?' +
+        'local=false&dataset=' + release + '_' + workflow + '_' + step + '_eventSize' +
+        '&resource=size_uncom&colours=default&groups=Group_' + step + '_23Sep_v1' +
+        '&threshold=0">[EventSize]</a>'
+      }));
+    }
+  }
+
+  stepLi.appendChild(sub);
+  parentUl.appendChild(stepLi);
+}
+
+function render() {
+  const root = document.getElementById('root');
+
+  // Group releases by family, preserving Python's sort.
+  const order = Object.keys(MANIFEST.releases);
+  const familyOrder = [];
+  const familyToReleases = {};
+  for (const rel of order) {
+    const fam = MANIFEST.releases[rel].family;
+    if (!familyToReleases[fam]) {
+      familyOrder.push(fam);
+      familyToReleases[fam] = [];
+    }
+    familyToReleases[fam].push(rel);
+  }
+
+  for (const family of familyOrder) {
+    const fst = MANIFEST.releases[familyToReleases[family][0]].family_short || '';
+    const details = el('details');
+    details.appendChild(el('summary', { text: family + '_X' }));
+    emitFamilyHeader(details, family, fst);
+
+    const wrapper = el('ul');
+    for (const rel of familyToReleases[family]) {
+      const info = MANIFEST.releases[rel];
+      const gcc = info.gcc;
+      if (!gcc) continue;
+      for (const wf of Object.keys(info.workflows || {})) {
+        const wfInfo = info.workflows[wf];
+        const stepEntries = Object.keys(wfInfo.steps || {}).map(function (k) { return [k, wfInfo.steps[k]]; });
+        if (!stepEntries.length) continue;
+
+        const wfLi = el('li', { html: '<strong>' + rel + '(' + wf + ')</strong><br>' });
+        const wfUl = el('ul');
+        if (wfInfo.has_cmdlog) {
+          wfUl.appendChild(el('li', { html:
+            '<a href="' + ADDR + 'cmdlog/' + rel + '/' + gcc + '/' + wf + '/cmdLog_profiling.txt">[cmdLog]</a>'
+          }));
+        }
+        for (const pair of stepEntries) {
+          const step = pair[0];
+          const cell = pair[1];
+          if (cell && !cell.error) emitStep(wfUl, rel, gcc, wf, step, cell);
+        }
+        wfLi.appendChild(wfUl);
+        wrapper.appendChild(wfLi);
+      }
+    }
+    details.appendChild(wrapper);
+    root.appendChild(details);
+    root.appendChild(el('hr'));
+  }
+}
+
+render();
+"""
 
 
 def main() -> None:
     if len(sys.argv) < 2:
         sys.exit("Usage: make_webpage.py <RECENT_RELEASE>")
-    recent_rel = sys.argv[1]
-    recent_family = family_of(recent_rel)
+    recent = sys.argv[1]
+    manifest = build_manifest(recent)
 
-    cmdlog_path = _common.result_subdir("cmdlog")
-    cmssw_list = sorted(os.listdir(cmdlog_path), key=release_sort_key)
-
-    out("""<!DOCTYPE html>
-<html>
-<head>
-</head>
-<body>""")
-
-    # Cache directory listings used inside the per-version block.
-    summary_html_dir = os.listdir(_common.result_subdir("summary_plot_html"))
-    hist_dir = os.listdir(_common.result_subdir("circles", "web", "hist"))
-    eventsize_plots = [p for p in hist_dir if "Eventsize" in p]
-    recent_plots = [p for p in hist_dir if "Recent" in p]
-
-    mother_family = ""
-    for cmssw in cmssw_list:
-        family = family_of(cmssw)
-
-        # On version-family boundary: close the previous <details>, open a new one.
-        if family != mother_family:
-            if mother_family:
-                out("</details>")
-                out('<hr size="3" noshade>')
-            mother_family = family
-            out(f"<details>\n\t<summary>{mother_family}_X</summary>")
-            out(f'\t<h2>{mother_family}_X <font size="4em"></font></h2>')
-
-            emit_summary_plot_links(mother_family, summary_html_dir)
-            out('<hr size="2" noshade>\n<br>')
-
-            family_short = "_".join(mother_family.split("_")[1:])
-            emit_eventsize_plot_links(family_short, eventsize_plots)
-            out('<hr size="2" noshade>\n<br>')
-
-            if mother_family == recent_family:
-                emit_recent_plot_links(recent_plots)
-                out('<hr size="2" noshade>\n<br>')
-
-        gcc = os.listdir(os.path.join(cmdlog_path, cmssw))[0]
-
-        for workflow in os.listdir(os.path.join(cmdlog_path, cmssw, gcc)):
-            tms_dir = _common.result_subdir("Time_Mem_Summary", cmssw, gcc, workflow)
-            if not os.path.isdir(tms_dir):
-                continue
-            tms_files = os.listdir(tms_dir)
-            if not tms_files:
-                continue
-
-            out(f"\n\t\t<li><strong>{cmssw}({workflow})</strong>\n\t\t<br>\n\t\t<ul>")
-
-            cmdlog_dir = _common.result_subdir("cmdlog", cmssw, gcc, workflow)
-            if "cmdLog_profiling.txt" in os.listdir(cmdlog_dir):
-                out(f'\n\t\t\t<li>\n\t\t\t<a href="{_common.RESULT_ADDRESS}cmdlog/'
-                    f'{cmssw}/{gcc}/{workflow}/cmdLog_profiling.txt" title="cmdLog">[cmdLog]</a>')
-
-            steps_seen = [s.split(".")[0] for s in tms_files if s.split(".")[0] in STEP_META]
-            for step in steps_seen:
-                emit_step_links(cmssw, gcc, workflow, step, family)
-
-            out("\t</ul>")
-
-    out("</details>\n</body>\n</html>")
+    sys.stdout.write(HTML_HEAD)
+    sys.stdout.write("<script>\n")
+    sys.stdout.write("const MANIFEST = ")
+    json.dump(manifest, sys.stdout)
+    sys.stdout.write(";\n")
+    sys.stdout.write(CLIENT_RENDER_JS)
+    sys.stdout.write("\n</script>\n")
+    sys.stdout.write(HTML_TAIL)
 
 
 if __name__ == "__main__":

--- a/jenkins/scripts/make_webpage.py
+++ b/jenkins/scripts/make_webpage.py
@@ -1,259 +1,278 @@
-import sys
+"""Render index.html for cms-reco-profiling.web.cern.ch.
+
+Reads everything that previous pipeline stages staged under RESULT_PATH and
+emits a single static HTML document on stdout. The inline shell redirects
+the output to index.html and xrdcopies to <webroot>/web/.
+
+Output preserves the historical structure: per-version <details> sections,
+followed by per-workflow nested lists with links to summary plots, RES files,
+igprof navigators, comparison previews, circles pie charts, etc.
+"""
+
+from __future__ import annotations
+
 import os
-import yaml
+import sys
 
-recent_rel = sys.argv[1]
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _common
 
-local_path = '../'
-result_path = '/eos/project/c/cmsweb/www/reco-prof/results'
-result_address = 'http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/'
 
-cmdlog_path = os.path.join(result_path,'cmdlog')
-cmssw_list = os.listdir(cmdlog_path)
-cmssw_list.sort(key = lambda x: (x.split('_')[1:4],10-len(x.split('_')),len(x)))
+# ── Per-step labelling ───────────────────────────────────────────────────────
+# step token  -> (workflow-section title token, summary-plot label, eventsize-plot label, recent8 label)
+STEP_META = {
+    "step2": ("step2_RAW(DIGI)",     "RAW_DIGI",     "RAW_DIGI",     "RAW_DIGI"),
+    "step3": ("step3_AOD(RECO)",     "RECO_AOD",     "RECO_AOD",     "RECO_AOD"),
+    "step4": ("step4_MiniAOD(PAT)",  "PAT_MiniAOD",  "PAT_MiniAOD",  "PAT_MiniAOD"),
+    "step5": ("step5_NanoAOD",       "NanoAOD",      "NanoAOD",      "NanoAOD"),
+}
+# Short label used in the summary-plot and event-size [bracketed link text].
+SHORT_LABEL = {
+    "step2": ("DIGI", "RAW"),
+    "step3": ("AOD",  "AOD"),
+    "step4": ("MINIAOD", "MINIAOD"),
+    "step5": ("NANOAOD", "NANOAOD"),
+}
 
-cmssw_yaml = {} 
 
-for i in cmssw_list:
-        gcc = os.listdir(os.path.join(cmdlog_path,i))[0]
-        cmssw_yaml[i] = {"gcc":gcc,"workflow":os.listdir(os.path.join(cmdlog_path,i,gcc))}
+def out(s: str = "") -> None:
+    print(s)
 
-mother_version = ''
-data_type = {"step2":"step2_RAW(DIGI)","step3":"step3_AOD(RECO)","step4":"step4_MiniAOD(PAT)","step5":"step5_NanoAOD"}
 
-print("""<!DOCTYPE html>
+def release_sort_key(release: str) -> tuple:
+    return (release.split("_")[1:4], 10 - len(release.split("_")), len(release))
+
+
+def family_of(release: str) -> str:
+    return "_".join(release.split("_")[:3])
+
+
+# ── Section emitters ─────────────────────────────────────────────────────────
+def emit_summary_plot_links(family: str, plots: list[str]) -> None:
+    """The 'Summary of <family>_X(<type>)(<wf>) [Short Summary ...]' block."""
+    for plot in plots:
+        if family not in plot:
+            continue
+        for step, (_, plot_label, _, _) in STEP_META.items():
+            if step not in plot:
+                continue
+            wf = ".".join(plot.split("_")[4].split(".")[0:1])
+            short = SHORT_LABEL[step][0]
+            out('<span style=" font: normal bold 1.0em Georgia, serif ; color: navy;">')
+            out(f'\t<h3>Summary of {family}_X({plot_label})({wf}) '
+                f'<font size="2em"><a target=\'_blank\' '
+                f'href="{_common.RESULT_ADDRESS}summary_plot_html/{plot}" '
+                f'title="shortSummary">[Short Summary Time and Memory({short})]</a></font></h3>')
+            break
+
+
+def emit_eventsize_plot_links(family_short: str, plots: list[str]) -> None:
+    """family_short: e.g. '14_0' (without 'CMSSW_' prefix)."""
+    for plot in plots:
+        if family_short not in plot:
+            continue
+        for step, (_, _, label, _) in STEP_META.items():
+            if step not in plot:
+                continue
+            wf = plot.split("_")[3].split(".")[0]
+            short = SHORT_LABEL[step][1]
+            out('<span style=" font: normal bold 1.0em Georgia, serif ; color: navy;">')
+            out(f'        <h3>EventSize Summary({label})({wf}) '
+                f'<font size="2em"><a target=\'_blank\' '
+                f'href="{_common.RESULT_ADDRESS}circles/web/hist/{plot}" '
+                f'title="shortSummary">[EventSize Summary({short})]</a></font></h3>')
+            break
+
+
+def emit_recent_plot_links(plots: list[str]) -> None:
+    for plot in plots:
+        if "Recent" not in plot:
+            continue
+        for step, (_, _, _, label) in STEP_META.items():
+            if step not in plot:
+                continue
+            wf = plot.split("_")[1].split(".")[0]
+            short = SHORT_LABEL[step][1]
+            out('<span style=" font: normal bold 1.0em Georgia, serif ; color: navy;">')
+            out(f'        <h3>Recent8 Summary({label})({wf}) '
+                f'<font size="2em"><a target=\'_blank\' '
+                f'href="{_common.RESULT_ADDRESS}circles/web/hist/{plot}" '
+                f'title="shortSummary">[Recent8 Summary({short})]</a></font></h3>')
+            break
+
+
+def emit_step_links(release: str, gcc: str, workflow: str, step: str, family: str) -> None:
+    """All per-step links inside a workflow's <ul> (the deepest level)."""
+    addr = _common.RESULT_ADDRESS
+    from_data = f"{release}/{gcc}/{workflow}/"
+    from_cgi = f"{release}/{workflow}/{step}/"
+
+    out(f'\n\t\t\t<li><strong>{STEP_META[step][0]}</strong>')
+    out('\n\t\t\t\t<ul>')
+    out(f'\n\t\t\t\t<li>\n\t\t\t\t<a href="{addr}Time_Mem_Summary/{from_data}{step}.txt" '
+        f'title="getTimeMemSummary">[getTimeMemSummary]</a>')
+    out(f'\n\t\t\t\t<a href="{addr}Time_Mem_Summary/{from_data}memory_report_{step}.txt" '
+        f'title="memory_report">[memory_report]</a>')
+
+    # IgProf navigator + .res txt links.
+    cgi_dir = f"/eos/project/c/cmsweb/www/reco-prof/cgi-bin/data/releases/{from_cgi}"
+    if os.path.isdir(cgi_dir):
+        res_dir = _common.result_subdir("RES", release, gcc, workflow)
+        if os.path.isdir(res_dir):
+            for res in (r for r in os.listdir(res_dir) if step in r):
+                if "cpu" in res:
+                    cgi_bin, ig_number = "cpu_endjob", ""
+                else:
+                    snap = res.split("_")[2].split(".")[0]
+                    cgi_bin, ig_number = f"mem_live.{snap}", snap
+                profiler = res.split("_")[1].split(".")[0]
+                out(f'\n\t\t\t<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/'
+                    f'cgi-bin/igprof-navigator/releases/{from_cgi}{cgi_bin}" '
+                    f'title="{profiler} time check">[{profiler} Profiler igprof{ig_number}]</a>'
+                    f'<a href="{addr}RES/{from_data}{res}" title="txtLink">[txtLink]</a>')
+
+    # Comparison block (TimeDiff + CompProd preview spans).
+    timediff_path = _common.result_subdir("TimeDiff", release, gcc, workflow, f"{step}.txt")
+    compprod_path = _common.result_subdir("CompProd", release, gcc, workflow, f"{step}.txt")
+    has_timediff = os.path.isfile(timediff_path)
+    has_compprod = os.path.isfile(compprod_path)
+
+    if has_timediff or has_compprod:
+        out('\n\t\t\t<li>Comparison :\n\t\t\t<ul>')
+
+    if has_timediff:
+        with open(timediff_path) as f:
+            last = f.readlines()[-1]
+        toks = last.split()
+        out(f'\n\t\t\t\t<li>\n\t\t\t\t<a href="{addr}TimeDiff/{from_data}{step}.txt" '
+            f'title="TimeDiff">[TimeDiff]</a>'
+            f'<span style=" font: Arial; font-size: small; color: green;"> '
+            f'preview: {toks[2]} s/ev ==> {toks[5]} s/ev </span>\n\t\t\t\t</li>')
+
+    if has_compprod:
+        with open(compprod_path) as f:
+            last = f.readlines()[-1]
+        toks = last.split()
+        out(f'\n\t\t\t\t<li>\n\t\t\t\t<a href="{addr}/CompProd/{from_data}{step}.txt" '
+            f'title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a>'
+            f'<span style=" font: Arial; font-size: small; color: red;"> '
+            f'preview: {toks[1]} ==> {toks[2]} </span>\n\t\t\t\t</li>')
+
+    if has_timediff or has_compprod:
+        out('\n\t\t\t</ul>')
+
+    # IgProf comparison HTMLs (currently unpopulated — those steps are
+    # commented out in the inline shell, but the rendering survives in case
+    # the directory is filled out-of-band).
+    igprof_dir = _common.result_subdir("comp_igprof", "html", from_cgi)
+    if os.path.isdir(igprof_dir):
+        pages = os.listdir(igprof_dir)
+        if pages:
+            out('\n\t\t\t<li>Igprof comparison :\n\t\t\t<ul>')
+            for page in pages:
+                if "cpu" in page:
+                    label = "cpu"
+                else:
+                    label = "mem." + page.split("_")[1].split(".")[1]
+                title = page.split("_")[0]
+                out(f'\n\t\t\t<li>\n\t\t\t<a href="{addr}comp_igprof/html/{from_cgi}{page}" '
+                    f'title="{title} compare">[{label} compare]</a>\n\t\t\t</li>')
+            out('\n\t\t\t</ul>')
+
+    # Circle pie chart + EventSize circle (skipped for the deprecated CMSSW_11_0
+    # branch and for workflow 136.889).
+    if family != "CMSSW_11_0" and workflow != "136.889":
+        circle_dataset = f"{release}%2F{gcc}%2F{workflow}%2F{step}_circles"
+        out('\n\t\t\t<li>Circle (Pie chart) :\n\t\t\t'
+            f'<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/'
+            f'circles/piechart.php?local=false&dataset={circle_dataset}'
+            f'&resource=time_real&colours=default&groups=reco_PhaseII_private&threshold=0" '
+            f'title="Circle">[Circle]</a>\n\t\t\t</li>')
+
+        eventsize_json = _common.result_subdir(
+            "circles", "web", "data",
+            f"{release}_{workflow}_{step}_eventSize.json")
+        if os.path.isfile(eventsize_json):
+            out('\n\t\t\t<li>EventSizeCircle (pie chart) :\n\t\t\t'
+                f'<a href="https://cms-reco-profiling.web.cern.ch/cms-reco-profiling/'
+                f'results/circles/web/eventsize.php?local=false&'
+                f'dataset={release}_{workflow}_{step}_eventSize&'
+                f'resource=size_uncom&colours=default&groups=Group_{step}_23Sep_v1'
+                f'&threshold=0" title="EventSize">[EventSize]</a>\n\t\t\t</li>')
+
+    out("\t\t</ul>")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        sys.exit("Usage: make_webpage.py <RECENT_RELEASE>")
+    recent_rel = sys.argv[1]
+    recent_family = family_of(recent_rel)
+
+    cmdlog_path = _common.result_subdir("cmdlog")
+    cmssw_list = sorted(os.listdir(cmdlog_path), key=release_sort_key)
+
+    out("""<!DOCTYPE html>
 <html>
 <head>
 </head>
-<body>"""
-)
+<body>""")
 
-for cmssw in cmssw_list:#Version Loop
+    # Cache directory listings used inside the per-version block.
+    summary_html_dir = os.listdir(_common.result_subdir("summary_plot_html"))
+    hist_dir = os.listdir(_common.result_subdir("circles", "web", "hist"))
+    eventsize_plots = [p for p in hist_dir if "Eventsize" in p]
+    recent_plots = [p for p in hist_dir if "Recent" in p]
 
-	child_version = '_'.join(cmssw.split('_')[0:3])
+    mother_family = ""
+    for cmssw in cmssw_list:
+        family = family_of(cmssw)
 
-	if mother_version != child_version:#Select First version in Categroy
+        # On version-family boundary: close the previous <details>, open a new one.
+        if family != mother_family:
+            if mother_family:
+                out("</details>")
+                out('<hr size="3" noshade>')
+            mother_family = family
+            out(f"<details>\n\t<summary>{mother_family}_X</summary>")
+            out(f'\t<h2>{mother_family}_X <font size="4em"></font></h2>')
 
-		if mother_version != '':
+            emit_summary_plot_links(mother_family, summary_html_dir)
+            out('<hr size="2" noshade>\n<br>')
 
-			print("""</details>""")
-			print("""<hr size=\"3\" noshade>""")
+            family_short = "_".join(mother_family.split("_")[1:])
+            emit_eventsize_plot_links(family_short, eventsize_plots)
+            out('<hr size="2" noshade>\n<br>')
 
-		mother_version = child_version
-		print("""<details>
-	<summary>{0}_X</summary>""".format(mother_version))
+            if mother_family == recent_family:
+                emit_recent_plot_links(recent_plots)
+                out('<hr size="2" noshade>\n<br>')
 
-		print(
-"""	<h2>{0}_X <font size="4em"></font></h2>""".format(mother_version)
-		)
+        gcc = os.listdir(os.path.join(cmdlog_path, cmssw))[0]
 
-		for sum_plot in os.listdir(os.path.join(result_path,'summary_plot_html')):#Summary plot Loop
+        for workflow in os.listdir(os.path.join(cmdlog_path, cmssw, gcc)):
+            tms_dir = _common.result_subdir("Time_Mem_Summary", cmssw, gcc, workflow)
+            if not os.path.isdir(tms_dir):
+                continue
+            tms_files = os.listdir(tms_dir)
+            if not tms_files:
+                continue
 
-			if mother_version in sum_plot:#Input Summary plot for same version
-				print(
-"""<span style=" font: normal bold 1.0em Georgia, serif ; color: navy;">"""
-				)
-				if "step2" in sum_plot:
-					print(
-"""	<h3>Summary of {0}_X(RAW_DIGI)({1}) <font size="2em"><a target='_blank' href="{2}summary_plot_html/{3}" title="shortSummary">[Short Summary Time and Memory(DIGI)]</a></font></h3>""".format(mother_version,'.'.join(sum_plot.split('_')[4].split('.')[0:1]),result_address,sum_plot)
-					)
-				if "step3" in sum_plot:
-					print(
-"""	<h3>Summary of {0}_X(RECO_AOD)({1}) <font size="2em"><a target='_blank' href="{2}summary_plot_html/{3}" title="shortSummary">[Short Summary Time and Memory(AOD)]</a></font></h3>""".format(mother_version,'.'.join(sum_plot.split('_')[4].split('.')[0:1]),result_address,sum_plot)
-					)
-				if "step4" in sum_plot:
-					print(
-"""	<h3>Summary of {0}_X(PAT_MiniAOD)({1}) <font size="2em"><a target='_blank' href="{2}summary_plot_html/{3}" title="shortSummary">[Short Summary Time and Memory(MINIAOD)]</a></font></h3>""".format(mother_version,'.'.join(sum_plot.split('_')[4].split('.')[0:1]),result_address,sum_plot)
-					)
-				if "step5" in sum_plot:
-					print(
-"""	<h3>Summary of {0}_X(NanoAOD)({1}) <font size="2em"><a target='_blank' href="{2}summary_plot_html/{3}" title="shortSummary">[Short Summary Time and Memory(NANOAOD)]</a></font></h3>""".format(mother_version,'.'.join(sum_plot.split('_')[4].split('.')[0:1]),result_address,sum_plot)
-					)
-		print(
-"""<hr size="2" noshade>
-<br>"""
-		)#End of Summary plot Loop
+            out(f"\n\t\t<li><strong>{cmssw}({workflow})</strong>\n\t\t<br>\n\t\t<ul>")
 
-		for sum_plot in [x for x in os.listdir(os.path.join(result_path,'circles/web/hist/')) if 'Eventsize' in x ]:#Summary plot Loop
+            cmdlog_dir = _common.result_subdir("cmdlog", cmssw, gcc, workflow)
+            if "cmdLog_profiling.txt" in os.listdir(cmdlog_dir):
+                out(f'\n\t\t\t<li>\n\t\t\t<a href="{_common.RESULT_ADDRESS}cmdlog/'
+                    f'{cmssw}/{gcc}/{workflow}/cmdLog_profiling.txt" title="cmdLog">[cmdLog]</a>')
 
-			if '_'.join(mother_version.split('_')[1:]) in sum_plot:#Input Summary plot for same version
-				print(
-"""<span style=" font: normal bold 1.0em Georgia, serif ; color: navy;">"""
-			)
-				if "step2" in sum_plot:
-					print(
-"""        <h3>EventSize Summary(RAW_DIGI)({1}) <font size="2em"><a target='_blank' href="{0}circles/web/hist/{2}" title="shortSummary">[EventSize Summary(RAW)]</a></font></h3>""".format(result_address,sum_plot.split('_')[3].split('.')[0],sum_plot)
-					)
-				if "step3" in sum_plot:
-					print(
-"""        <h3>EventSize Summary(RECO_AOD)({1}) <font size="2em"><a target='_blank' href="{0}circles/web/hist/{2}" title="shortSummary">[EventSize Summary(AOD)]</a></font></h3>""".format(result_address,sum_plot.split('_')[3].split('.')[0],sum_plot)
-					)
-				if "step4" in sum_plot:
-					print(
-"""        <h3>EventSize Summary(PAT_MiniAOD)({1}) <font size="2em"><a target='_blank' href="{0}circles/web/hist/{2}" title="shortSummary">[EventSize Summary(MINIAOD)]</a></font></h3>""".format(result_address,sum_plot.split('_')[3].split('.')[0],sum_plot)
-					)
-				if "step5" in sum_plot:
-					print(
-"""        <h3>EventSize Summary(NanoAOD)({1}) <font size="2em"><a target='_blank' href="{0}circles/web/hist/{2}" title="shortSummary">[EventSize Summary(NANOAOD)]</a></font></h3>""".format(result_address,sum_plot.split('_')[3].split('.')[0],sum_plot)
-					)
-		print(
-"""<hr size="2" noshade>
-<br>"""
-		)#End of Summary plot Loop
+            steps_seen = [s.split(".")[0] for s in tms_files if s.split(".")[0] in STEP_META]
+            for step in steps_seen:
+                emit_step_links(cmssw, gcc, workflow, step, family)
+
+            out("\t</ul>")
+
+    out("</details>\n</body>\n</html>")
 
 
-		if mother_version == '_'.join(recent_rel.split('_')[0:3]):
-			for sum_plot in [x for x in os.listdir(os.path.join(result_path,'circles/web/hist/')) if 'Recent' in x ]:#Summary plot Loop
-	
-				if 'Recent' in sum_plot:#Input Summary plot for same version
-					print(
-	"""<span style=" font: normal bold 1.0em Georgia, serif ; color: navy;">"""
-				)
-					if "step2" in sum_plot:
-						print(
-	"""        <h3>Recent8 Summary(RAW_DIGI)({1}) <font size="2em"><a target='_blank' href="{0}circles/web/hist/{2}" title="shortSummary">[Recent8 Summary(RAW)]</a></font></h3>""".format(result_address,sum_plot.split('_')[1].split('.')[0],sum_plot)
-						)
-					if "step3" in sum_plot:
-						print(
-	"""        <h3>Recent8 Summary(RECO_AOD)({1}) <font size="2em"><a target='_blank' href="{0}circles/web/hist/{2}" title="shortSummary">[Recent8 Summary(AOD)]</a></font></h3>""".format(result_address,sum_plot.split('_')[1].split('.')[0],sum_plot)
-						)
-					if "step4" in sum_plot:
-						print(
-	"""        <h3>Recent8 Summary(PAT_MiniAOD)({1}) <font size="2em"><a target='_blank' href="{0}circles/web/hist/{2}" title="shortSummary">[Recent8 Summary(MINIAOD)]</a></font></h3>""".format(result_address,sum_plot.split('_')[1].split('.')[0],sum_plot)
-						)
-					if "step5" in sum_plot:
-						print(
-	"""        <h3>Recent8 Summary(NanoAOD)({1}) <font size="2em"><a target='_blank' href="{0}circles/web/hist/{2}" title="shortSummary">[Recent8 Summary(NANOAOD)]</a></font></h3>""".format(result_address,sum_plot.split('_')[1].split('.')[0],sum_plot)
-						)
-			print(
-	"""<hr size="2" noshade>
-	<br>"""
-			)#End of Summary plot Loop
-#-----------------------------------------------------------------------------------------------------------------------------------------------------------
-	gcc = cmssw_yaml[cmssw]['gcc']
-	
-	for workflow in cmssw_yaml[cmssw]['workflow']:#Workflow Loop
-
-		TMS_file = os.listdir('{0}/Time_Mem_Summary/{1}/{2}/{3}'.format(result_path,cmssw,gcc,workflow))
-
-		if len(TMS_file) == 0:#Select empty TMS dir
-
-			continue;
-
-		print("""
-		<li><strong>{0}({1})</strong>
-		<br>
-		<ul>""".format(cmssw,workflow))
-		
-		if "cmdLog_profiling.txt" in os.listdir("/{0}/cmdlog/{1}/{2}/{3}".format(result_path,cmssw,gcc,workflow)):
-			print("""
-			<li>
-			<a href="{0}cmdlog/{1}/{2}/{3}/cmdLog_profiling.txt" title="cmdLog">[cmdLog]</a>""".format(result_address,cmssw,gcc,workflow))
-
-		for step in [i.split('.')[0] for i in TMS_file if i.split('.')[0] in data_type]:
-
-			from_data_path = "{0}/{1}/{2}/".format(cmssw,gcc,workflow)
-			from_cgi_path = "{0}/{1}/{2}/".format(cmssw,workflow,step)
-			print("""
-			<li><strong>{}</strong>""".format(data_type[step]))
-			print("""
-				<ul>
-				<li>
-				<a href="{0}Time_Mem_Summary/{1}{2}.txt" title="getTimeMemSummary">[getTimeMemSummary]</a>""".format(result_address,from_data_path,step)
-			)
-			print("""
-				<a href="{0}Time_Mem_Summary/{1}memory_report_{2}.txt" title="memory_report">[memory_report]</a>""".format(result_address,from_data_path,step)
-			)
-
-#-----------------------------------------------------------------------------------------------------------------------------------------------------------
-			if os.path.isdir("/eos/project/c/cmsweb/www/reco-prof/cgi-bin/data/releases/{}".format(from_cgi_path)):
-				res_list = os.listdir("{0}/RES/{1}".format(result_path,from_data_path))
-				if len(res_list) != 0:
-					for res in [i for i in res_list if step in i]:
-						if "cpu" in res:
-							cgi_bin = "cpu_endjob"
-							ig_number = ""
-						if "mem" in res:
-							cgi_bin = "mem_live.{}".format(res.split('_')[2].split('.')[0])
-							ig_number = str(res.split('_')[2].split('.')[0])
-						print("""
-				<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/cgi-bin/igprof-navigator/releases/{0}{1}" title="{2} time check">[{3} Profiler igprof{4}]</a><a href="{5}RES/{6}{7}" title="txtLink">[txtLink]</a>""".format(from_cgi_path,cgi_bin,res.split('_')[1].split('.')[0],res.split('_')[1].split('.')[0],ig_number,result_address,from_data_path,res)
-						)
-
-#-----------------------------------------------------------------------------------------------------------------------------------------------------------
-			if os.path.isfile("{0}/TimeDiff/{1}{2}.txt".format(result_path,from_data_path,step)) or os.path.isfile("{0}/CompProd/{1}{2}.txt".format(result_path,from_data_path,step)):
-
-				print("""
-			<li>Comparison :
-			<ul>""")
-
-			if os.path.isfile("{0}/TimeDiff/{1}{2}.txt".format(result_path,from_data_path,step)):
-				f = open("{0}/TimeDiff/{1}{2}.txt".format(result_path,from_data_path,step))
-				timediff = f.readlines()[-1]
-
-				print("""
-				<li>
-				<a href="{0}TimeDiff/{1}{2}.txt" title="TimeDiff">[TimeDiff]</a><span style=" font: Arial; font-size: small; color: green;"> preview: {3} s/ev ==> {4} s/ev </span>
-				</li>""".format(result_address,from_data_path,step,timediff.split()[2],timediff.split()[5])				)
-
-			if os.path.isfile("{0}/CompProd/{1}{2}.txt".format(result_path,from_data_path,step)):
-				f = open("{0}/CompProd/{1}{2}.txt".format(result_path,from_data_path,step))
-				compprod = f.readlines()[-1]
-
-				print("""
-				<li>
-				<a href="{0}/CompProd/{1}{2}.txt" title="Compare_Out_Prod">[CompareOutProd (edmEventSize)]</a><span style=" font: Arial; font-size: small; color: red;"> preview: {3} ==> {4} </span>
-				</li>""".format(result_address,from_data_path,step,compprod.split()[1],compprod.split()[2]))
-
-			if os.path.isfile("{0}/TimeDiff/{1}{2}.txt".format(result_path,from_data_path,step)) or os.path.isfile("{0}/CompProd/{1}{2}.txt".format(result_path,from_data_path,step)):
-
-				print("""
-			</ul>""")
-
-#-----------------------------------------------------------------------------------------------------------------------------------------------------------
-			if os.path.isdir("{0}/comp_igprof/html/{1}".format(result_path,from_cgi_path)):
-				comp_igprof = os.listdir("{0}/comp_igprof/html/{1}".format(result_path,from_cgi_path))
-				if len(comp_igprof) != 0:
-					print("""
-			<li>Igprof comparison :
-			<ul>""")
-				for igprof_page in comp_igprof:
-					if "cpu" in igprof_page:
-						igprof_type = "cpu"
-					else:
-						igprof_type = "mem." + igprof_page.split('_')[1].split('.')[1]
-					print("""
-			<li>
-			<a href="{0}comp_igprof/html/{1}{2}" title="{3} compare">[{4} compare]</a>
-			</li>""".format(result_address,from_cgi_path,igprof_page,igprof_page.split('_')[0],igprof_type)
-					)
-				if len(comp_igprof) != 0:
-					print("""
-			</ul>"""
-)
-
-#-----------------------------------------------------------------------------------------------------------------------------------------------------------
-			if child_version != "CMSSW_11_0":
-				if workflow != "136.889":
-					print("""
-			<li>Circle (Pie chart) :
-			<a href="http://cms-reco-profiling.web.cern.ch/cms-reco-profiling/{0}" title="Circle">[Circle]</a>
-			</li>""".format("circles/piechart.php?local=false&dataset="+cmssw+"%2F"+gcc+"%2F"+workflow+"%2F"+step+"_circles&resource=time_real&colours=default&groups=reco_PhaseII_private&threshold=0")
-				)
-					if os.path.isfile("{0}/circles/web/data/{1}_{2}_{3}_eventSize.json".format(result_path,cmssw,workflow,step)):
-							print("""
-			<li>EventSizeCircle (pie chart) :
-			<a href="https://cms-reco-profiling.web.cern.ch/cms-reco-profiling/results/circles/web/eventsize.php?local=false&dataset={0}_{1}_{2}_eventSize&resource=size_uncom&colours=default&groups=Group_{2}_23Sep_v1&threshold=0" title="EventSize">[EventSize]</a>
-			</li>""".format(cmssw,workflow,step)
-			)
-			print(
-"		</ul>"
-)
-
-		print(
-"	</ul>"
-)
-
-print("""</details>
-</body>
-</html>""")
+if __name__ == "__main__":
+    main()

--- a/jenkins/scripts/make_webpage.py
+++ b/jenkins/scripts/make_webpage.py
@@ -224,13 +224,33 @@ def build_release(release: str) -> dict:
 
 
 def group_summary_plots(plots: list[str], releases: dict) -> dict[str, list[str]]:
-    """Family-name → matching summary_plot_html filenames."""
+    """Family-name → matching per-step summary_plot_html filenames.
+
+    Excludes <family>_maxmem.html which is grouped separately so it can get
+    its own dedicated link slot in the family header.
+    """
     families = sorted({r["family"] for r in releases.values() if r.get("family")})
     out: dict[str, list[str]] = {f: [] for f in families}
     for plot in plots:
+        if "_maxmem" in plot:
+            continue  # handled by group_maxmem_plots()
         for fam in families:
             if fam in plot:
                 out[fam].append(plot)
+                break
+    return out
+
+
+def group_maxmem_plots(plots: list[str], releases: dict) -> dict[str, str]:
+    """Family-name → its single <family>_maxmem.html filename (if any)."""
+    families = sorted({r["family"] for r in releases.values() if r.get("family")})
+    out: dict[str, str] = {}
+    for plot in plots:
+        if "_maxmem" not in plot:
+            continue
+        for fam in families:
+            if plot.startswith(fam + "_maxmem"):
+                out[fam] = plot
                 break
     return out
 
@@ -271,6 +291,7 @@ def build_manifest(recent_release: str) -> dict:
         "result_address": _common.RESULT_ADDRESS,
         "step_meta": STEP_META,
         "summary_plots_by_family": group_summary_plots(summary_html, releases),
+        "maxmem_plot_by_family": group_maxmem_plots(summary_html, releases),
         "eventsize_plots_by_family_short": group_eventsize_plots(
             [p for p in hist if "Eventsize" in p], releases),
         "recent_plots": [p for p in hist if "Recent" in p],
@@ -292,11 +313,6 @@ HTML_HEAD = """<!DOCTYPE html>
   .preview-time { font-size: small; color: green; }
   .preview-size { font-size: small; color: red; }
   .max-mem    { font-size: small; color: #0066cc; font-weight: 600; }
-  .mem-chart  { margin: 0.4em 0 0.8em 0; }
-  .mem-chart svg { display: block; max-width: 100%; height: auto; background: #fafafa;
-                   border: 1px solid #ddd; border-radius: 4px; }
-  .mem-legend { font-size: small; margin: 0.2em 0; }
-  .mem-legend span { display: inline-block; padding: 0 0.6em; margin-right: 0.3em; }
   ul { padding-left: 1.5em; }
   hr { margin: 0.8em 0; }
   a { text-decoration: none; }
@@ -334,127 +350,20 @@ function detectStep(name) {
   return null;
 }
 
-// Per-step colours for the AllocMonitor bar chart. Step3 is the headline RECO
-// step; step4/step5 are the lighter MiniAOD/NanoAOD passes.
+// Per-step colours retained for legend badges next to other plot links.
 const STEP_COLOURS = { step2: '#94a3b8', step3: '#2563eb', step4: '#16a34a', step5: '#f97316' };
-
-function shortReleaseLabel(rel) {
-  // CMSSW_16_1_0_pre3 → "16_1_0_pre3"
-  return rel.replace(/^CMSSW_/, '');
-}
-
-function buildMemoryChart(family, releases) {
-  // Collect (release, workflow, step, gb) tuples. Group by workflow.
-  const byWf = {};
-  for (const rel of releases) {
-    const info = MANIFEST.releases[rel];
-    if (!info || !info.workflows) continue;
-    for (const wf of Object.keys(info.workflows)) {
-      const wfInfo = info.workflows[wf];
-      if (!wfInfo.steps) continue;
-      for (const step of Object.keys(wfInfo.steps)) {
-        const cell = wfInfo.steps[step];
-        if (!cell || !cell.max_memory || cell.max_memory.max_used == null) continue;
-        if (!byWf[wf]) byWf[wf] = {};
-        if (!byWf[wf][rel]) byWf[wf][rel] = {};
-        byWf[wf][rel][step] = cell.max_memory.max_used / 1e9;  // bytes → GB
-      }
-    }
-  }
-
-  if (Object.keys(byWf).length === 0) return null;
-
-  const wrapper = el('div', { html: '<div style="font-weight:600;color:#0066cc;margin:0.4em 0;">' +
-    'Max Memory (AllocMonitor) — release × workflow comparison</div>' });
-
-  for (const wf of Object.keys(byWf).sort()) {
-    const relsHere = releases.filter(function(r) { return byWf[wf][r]; });
-    if (!relsHere.length) continue;
-
-    const stepsPresent = STEPS.filter(function(s) {
-      return relsHere.some(function(r) { return byWf[wf][r][s] != null; });
-    });
-    if (!stepsPresent.length) continue;
-
-    // Layout
-    const W = Math.max(360, 60 + relsHere.length * (28 + stepsPresent.length * 14));
-    const H = 200;
-    const padL = 50, padR = 10, padT = 25, padB = 70;
-    const plotW = W - padL - padR;
-    const plotH = H - padT - padB;
-
-    let maxGB = 0;
-    for (const r of relsHere) for (const s of stepsPresent) {
-      const v = byWf[wf][r][s];
-      if (v != null && v > maxGB) maxGB = v;
-    }
-    if (maxGB <= 0) continue;
-    const yMax = Math.ceil(maxGB * 1.1 * 10) / 10;  // round up to 0.1 GB
-
-    const barGroupW = plotW / relsHere.length;
-    const barW = Math.max(3, (barGroupW - 6) / stepsPresent.length);
-
-    let svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + W + ' ' + H + '" width="' + W + '" height="' + H + '">';
-    // Title
-    svg += '<text x="' + (W / 2) + '" y="14" text-anchor="middle" font-size="11" font-weight="600">' +
-           'Workflow ' + wf + ' (peak GB)</text>';
-    // Y axis
-    svg += '<line x1="' + padL + '" y1="' + padT + '" x2="' + padL + '" y2="' + (padT + plotH) + '" stroke="#555"/>';
-    // 4 horizontal grid lines + Y labels
-    for (let i = 0; i <= 4; i++) {
-      const y = padT + plotH - (plotH * i / 4);
-      const v = (yMax * i / 4).toFixed(1);
-      svg += '<line x1="' + padL + '" y1="' + y + '" x2="' + (padL + plotW) + '" y2="' + y +
-             '" stroke="#eee"/>';
-      svg += '<text x="' + (padL - 4) + '" y="' + (y + 3) + '" text-anchor="end" font-size="9" fill="#666">' + v + '</text>';
-    }
-    // X axis
-    svg += '<line x1="' + padL + '" y1="' + (padT + plotH) + '" x2="' + (padL + plotW) +
-           '" y2="' + (padT + plotH) + '" stroke="#555"/>';
-
-    // Bars
-    for (let i = 0; i < relsHere.length; i++) {
-      const r = relsHere[i];
-      const groupX = padL + i * barGroupW + 3;
-      // X label (release short, rotated -45deg)
-      const labelX = groupX + barGroupW / 2 - 3;
-      const labelY = padT + plotH + 12;
-      svg += '<text x="' + labelX + '" y="' + labelY + '" text-anchor="end" font-size="9" fill="#333" ' +
-             'transform="rotate(-45 ' + labelX + ' ' + labelY + ')">' + shortReleaseLabel(r) + '</text>';
-
-      for (let j = 0; j < stepsPresent.length; j++) {
-        const s = stepsPresent[j];
-        const v = byWf[wf][r][s];
-        if (v == null) continue;
-        const h = (v / yMax) * plotH;
-        const x = groupX + j * barW;
-        const y = padT + plotH - h;
-        svg += '<rect x="' + x.toFixed(1) + '" y="' + y.toFixed(1) + '" width="' + barW.toFixed(1) +
-               '" height="' + h.toFixed(1) + '" fill="' + STEP_COLOURS[s] + '">' +
-               '<title>' + r + ' / ' + s + ': ' + v.toFixed(2) + ' GB</title></rect>';
-      }
-    }
-    svg += '</svg>';
-
-    const chartDiv = el('div', { html:
-      '<div class="mem-chart">' + svg + '</div>' +
-      '<div class="mem-legend">' + stepsPresent.map(function(s) {
-        return '<span style="background:' + STEP_COLOURS[s] + ';color:white;border-radius:3px;">' +
-               STEP_META[s].short + '</span>';
-      }).join(' ') + '</div>'
-    });
-    wrapper.appendChild(chartDiv);
-  }
-  return wrapper;
-}
 
 function emitFamilyHeader(details, family, familyShort, familyReleases) {
   details.appendChild(el('h2', { html: family + '_X' }));
 
-  // AllocMonitor / MaxMemoryPreload comparison chart for this family.
-  const memChart = buildMemoryChart(family, familyReleases);
-  if (memChart) {
-    details.appendChild(memChart);
+  // AllocMonitor / MaxMemoryPreload chart on its own page (in summary_plot_html/).
+  const maxmemPlot = MANIFEST.maxmem_plot_by_family && MANIFEST.maxmem_plot_by_family[family];
+  if (maxmemPlot) {
+    details.appendChild(el('h3', { html:
+      'Max Memory (AllocMonitor) — ' + family + '_X ' +
+      '<a target="_blank" href="' + ADDR + 'summary_plot_html/' + maxmemPlot +
+      '" title="MaxMemoryPreload comparison">[Max Memory plot]</a>'
+    }));
     details.appendChild(el('hr'));
   }
 

--- a/jenkins/scripts/make_webpage.py
+++ b/jenkins/scripts/make_webpage.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from typing import Any
 
@@ -55,6 +56,43 @@ def safe_last_tokens(path: str, min_count: int) -> list[str] | None:
         return None
     toks = lines[-1].split()
     return toks if len(toks) >= min_count else None
+
+
+# Five "Memory Report:" patterns produced by the AllocMonitor + MaxMemoryPreload
+# LD_PRELOAD pair. The trailing block at job end carries the real peak memory.
+_MEM_PATTERNS = {
+    "total_requested": re.compile(r"total memory requested:\s*(-?\d+)"),
+    "max_used":        re.compile(r"max memory used:\s*(-?\d+)"),
+    "presently_used":  re.compile(r"presently used:\s*(-?\d+)"),
+    "allocations":     re.compile(r"# allocations calls:\s*(-?\d+)"),
+    "deallocations":   re.compile(r"# deallocations calls:\s*(-?\d+)"),
+}
+
+
+def parse_memory_report(path: str) -> dict | None:
+    """Read `memory_report_step{N}.txt` and pull the last value for each AllocMonitor
+    metric (bytes for memory, count for alloc/dealloc).
+
+    The file may contain one or several "Memory Report:" blocks (per-thread initial
+    + the final end-of-job summary). We always take the *last* value for each key,
+    which corresponds to the job-final summary — the one Javier asked us to plot.
+    """
+    try:
+        with open(path) as f:
+            text = f.read()
+    except OSError:
+        return None
+
+    out: dict[str, int] = {}
+    for key, pat in _MEM_PATTERNS.items():
+        matches = pat.findall(text)
+        if not matches:
+            continue
+        try:
+            out[key] = int(matches[-1])
+        except ValueError:
+            pass
+    return out or None
 
 
 # ── Sorting & family helpers ────────────────────────────────────────────────
@@ -134,6 +172,17 @@ def build_step_cell(release: str, gcc: str, workflow: str, step: str) -> dict:
     )
     if os.path.isfile(json_path):
         cell["has_eventsize_circle"] = True
+
+    # AllocMonitor / MaxMemoryPreload — end-of-job peak memory.
+    # Source: memory_report_step{N}.txt that found_report.py extracted from
+    # the cmsRun log. Per Javier's 2025-11-26 request: surface this on the
+    # web page since VSIZE/RSS were inaccurate.
+    mem_path = _common.result_subdir(
+        "Time_Mem_Summary", release, gcc, workflow, f"memory_report_{step}.txt")
+    if os.path.isfile(mem_path):
+        mem = parse_memory_report(mem_path)
+        if mem:
+            cell["max_memory"] = mem
 
     return cell
 
@@ -242,6 +291,12 @@ HTML_HEAD = """<!DOCTYPE html>
   h3 { font: normal bold 1.0em Georgia, serif; color: navy; margin: 0.3em 0; }
   .preview-time { font-size: small; color: green; }
   .preview-size { font-size: small; color: red; }
+  .max-mem    { font-size: small; color: #0066cc; font-weight: 600; }
+  .mem-chart  { margin: 0.4em 0 0.8em 0; }
+  .mem-chart svg { display: block; max-width: 100%; height: auto; background: #fafafa;
+                   border: 1px solid #ddd; border-radius: 4px; }
+  .mem-legend { font-size: small; margin: 0.2em 0; }
+  .mem-legend span { display: inline-block; padding: 0 0.6em; margin-right: 0.3em; }
   ul { padding-left: 1.5em; }
   hr { margin: 0.8em 0; }
   a { text-decoration: none; }
@@ -279,8 +334,129 @@ function detectStep(name) {
   return null;
 }
 
-function emitFamilyHeader(details, family, familyShort) {
+// Per-step colours for the AllocMonitor bar chart. Step3 is the headline RECO
+// step; step4/step5 are the lighter MiniAOD/NanoAOD passes.
+const STEP_COLOURS = { step2: '#94a3b8', step3: '#2563eb', step4: '#16a34a', step5: '#f97316' };
+
+function shortReleaseLabel(rel) {
+  // CMSSW_16_1_0_pre3 → "16_1_0_pre3"
+  return rel.replace(/^CMSSW_/, '');
+}
+
+function buildMemoryChart(family, releases) {
+  // Collect (release, workflow, step, gb) tuples. Group by workflow.
+  const byWf = {};
+  for (const rel of releases) {
+    const info = MANIFEST.releases[rel];
+    if (!info || !info.workflows) continue;
+    for (const wf of Object.keys(info.workflows)) {
+      const wfInfo = info.workflows[wf];
+      if (!wfInfo.steps) continue;
+      for (const step of Object.keys(wfInfo.steps)) {
+        const cell = wfInfo.steps[step];
+        if (!cell || !cell.max_memory || cell.max_memory.max_used == null) continue;
+        if (!byWf[wf]) byWf[wf] = {};
+        if (!byWf[wf][rel]) byWf[wf][rel] = {};
+        byWf[wf][rel][step] = cell.max_memory.max_used / 1e9;  // bytes → GB
+      }
+    }
+  }
+
+  if (Object.keys(byWf).length === 0) return null;
+
+  const wrapper = el('div', { html: '<div style="font-weight:600;color:#0066cc;margin:0.4em 0;">' +
+    'Max Memory (AllocMonitor) — release × workflow comparison</div>' });
+
+  for (const wf of Object.keys(byWf).sort()) {
+    const relsHere = releases.filter(function(r) { return byWf[wf][r]; });
+    if (!relsHere.length) continue;
+
+    const stepsPresent = STEPS.filter(function(s) {
+      return relsHere.some(function(r) { return byWf[wf][r][s] != null; });
+    });
+    if (!stepsPresent.length) continue;
+
+    // Layout
+    const W = Math.max(360, 60 + relsHere.length * (28 + stepsPresent.length * 14));
+    const H = 200;
+    const padL = 50, padR = 10, padT = 25, padB = 70;
+    const plotW = W - padL - padR;
+    const plotH = H - padT - padB;
+
+    let maxGB = 0;
+    for (const r of relsHere) for (const s of stepsPresent) {
+      const v = byWf[wf][r][s];
+      if (v != null && v > maxGB) maxGB = v;
+    }
+    if (maxGB <= 0) continue;
+    const yMax = Math.ceil(maxGB * 1.1 * 10) / 10;  // round up to 0.1 GB
+
+    const barGroupW = plotW / relsHere.length;
+    const barW = Math.max(3, (barGroupW - 6) / stepsPresent.length);
+
+    let svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + W + ' ' + H + '" width="' + W + '" height="' + H + '">';
+    // Title
+    svg += '<text x="' + (W / 2) + '" y="14" text-anchor="middle" font-size="11" font-weight="600">' +
+           'Workflow ' + wf + ' (peak GB)</text>';
+    // Y axis
+    svg += '<line x1="' + padL + '" y1="' + padT + '" x2="' + padL + '" y2="' + (padT + plotH) + '" stroke="#555"/>';
+    // 4 horizontal grid lines + Y labels
+    for (let i = 0; i <= 4; i++) {
+      const y = padT + plotH - (plotH * i / 4);
+      const v = (yMax * i / 4).toFixed(1);
+      svg += '<line x1="' + padL + '" y1="' + y + '" x2="' + (padL + plotW) + '" y2="' + y +
+             '" stroke="#eee"/>';
+      svg += '<text x="' + (padL - 4) + '" y="' + (y + 3) + '" text-anchor="end" font-size="9" fill="#666">' + v + '</text>';
+    }
+    // X axis
+    svg += '<line x1="' + padL + '" y1="' + (padT + plotH) + '" x2="' + (padL + plotW) +
+           '" y2="' + (padT + plotH) + '" stroke="#555"/>';
+
+    // Bars
+    for (let i = 0; i < relsHere.length; i++) {
+      const r = relsHere[i];
+      const groupX = padL + i * barGroupW + 3;
+      // X label (release short, rotated -45deg)
+      const labelX = groupX + barGroupW / 2 - 3;
+      const labelY = padT + plotH + 12;
+      svg += '<text x="' + labelX + '" y="' + labelY + '" text-anchor="end" font-size="9" fill="#333" ' +
+             'transform="rotate(-45 ' + labelX + ' ' + labelY + ')">' + shortReleaseLabel(r) + '</text>';
+
+      for (let j = 0; j < stepsPresent.length; j++) {
+        const s = stepsPresent[j];
+        const v = byWf[wf][r][s];
+        if (v == null) continue;
+        const h = (v / yMax) * plotH;
+        const x = groupX + j * barW;
+        const y = padT + plotH - h;
+        svg += '<rect x="' + x.toFixed(1) + '" y="' + y.toFixed(1) + '" width="' + barW.toFixed(1) +
+               '" height="' + h.toFixed(1) + '" fill="' + STEP_COLOURS[s] + '">' +
+               '<title>' + r + ' / ' + s + ': ' + v.toFixed(2) + ' GB</title></rect>';
+      }
+    }
+    svg += '</svg>';
+
+    const chartDiv = el('div', { html:
+      '<div class="mem-chart">' + svg + '</div>' +
+      '<div class="mem-legend">' + stepsPresent.map(function(s) {
+        return '<span style="background:' + STEP_COLOURS[s] + ';color:white;border-radius:3px;">' +
+               STEP_META[s].short + '</span>';
+      }).join(' ') + '</div>'
+    });
+    wrapper.appendChild(chartDiv);
+  }
+  return wrapper;
+}
+
+function emitFamilyHeader(details, family, familyShort, familyReleases) {
   details.appendChild(el('h2', { html: family + '_X' }));
+
+  // AllocMonitor / MaxMemoryPreload comparison chart for this family.
+  const memChart = buildMemoryChart(family, familyReleases);
+  if (memChart) {
+    details.appendChild(memChart);
+    details.appendChild(el('hr'));
+  }
 
   const sumPlots = MANIFEST.summary_plots_by_family[family] || [];
   for (const p of sumPlots) {
@@ -335,9 +511,17 @@ function emitStep(parentUl, release, gcc, workflow, step, cell) {
   const stepLi = el('li', { html: '<strong>' + meta.long + '</strong>' });
   const sub = el('ul');
 
+  // Inline AllocMonitor / MaxMemoryPreload max-memory metric (per Javier's request).
+  // Shown next to [memory_report] so the user sees the trustworthy peak immediately.
+  let memSpan = '';
+  if (cell.max_memory && cell.max_memory.max_used != null) {
+    const gb = (cell.max_memory.max_used / 1e9).toFixed(2);
+    memSpan = ' <span class="max-mem">Max Memory (AllocMonitor): ' + gb + ' GB</span>';
+  }
   sub.appendChild(el('li', { html:
     '<a href="' + ADDR + 'Time_Mem_Summary/' + fromData + step + '.txt">[getTimeMemSummary]</a> ' +
-    '<a href="' + ADDR + 'Time_Mem_Summary/' + fromData + 'memory_report_' + step + '.txt">[memory_report]</a>'
+    '<a href="' + ADDR + 'Time_Mem_Summary/' + fromData + 'memory_report_' + step + '.txt">[memory_report]</a>' +
+    memSpan
   }));
 
   if (cell.has_igprof_navigator && cell.igprof) {
@@ -432,7 +616,7 @@ function render() {
     const fst = MANIFEST.releases[familyToReleases[family][0]].family_short || '';
     const details = el('details');
     details.appendChild(el('summary', { text: family + '_X' }));
-    emitFamilyHeader(details, family, fst);
+    emitFamilyHeader(details, family, fst, familyToReleases[family]);
 
     const wrapper = el('ul');
     for (const rel of familyToReleases[family]) {

--- a/jenkins/scripts/pre-environment/make_jenkins_env.py
+++ b/jenkins/scripts/pre-environment/make_jenkins_env.py
@@ -1,21 +1,62 @@
+"""Pre-create the result directory tree on EOS and stage cmdLog_profiling files.
+
+Sweeps every (release, arch, workflow) found under DATA_DIR and ensures a
+matching subtree exists under each RESULT_PATH/<category>/ that the rest of
+the pipeline writes into. Also copies cmdLog_profiling.sh -> cmdLog_profiling.txt.
+
+The original implementation called `cp` with `os.system` and missed the parent
+mkdir, producing dozens of "cannot create regular file" errors per build. This
+version uses `shutil.copy2` and creates the parent directory beforehand.
+"""
+
+from __future__ import annotations
+
 import os
+import shutil
 import sys
-from shutil import copyfile
-import yaml
 
-data_path = '/eos/cms/store/user/cmsbuild/profiling/data/'
-results_path = '/eos/project/c/cmsweb/www/reco-prof/results/' 
-cmssw = os.listdir(data_path)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import _common
 
-workflow ={}
 
-for result_dir in os.listdir(results_path):
-	if result_dir == 'comp_igprof' or result_dir == 'summary_plot_html':
-		continue
-	for i in cmssw:
-		gcc = os.listdir(data_path + i)[0]
-		workflow[i] = {"gcc":gcc,"workflow":os.listdir(data_path + i +'/' + gcc)}
-		for j in os.listdir(data_path + i + '/' + gcc):
-			child_dir = results_path + result_dir + '/' + i + '/' + gcc + '/' + j
-			os.makedirs(child_dir,exist_ok=True) 
-			os.system("cp {0}{1}/{2}/{3}/cmdLog_profiling.sh {4}cmdlog/{1}/{2}/{3}/cmdLog_profiling.txt".format(data_path,i,gcc,j,results_path))
+def main() -> None:
+    data_path = _common.DATA_DIR
+    results_path = _common.RESULT_PATH
+
+    if not os.path.isdir(data_path):
+        sys.exit(f"profiling data root not found: {data_path}")
+    if not os.path.isdir(results_path):
+        sys.exit(f"web results root not found: {results_path}")
+
+    cmssw_releases = sorted(os.listdir(data_path))
+
+    # Categories that mirror the (release, arch, workflow) tree. comp_igprof
+    # and summary_plot_html have flat layouts so they're skipped here.
+    categories = [
+        d for d in os.listdir(results_path)
+        if d not in {"comp_igprof", "summary_plot_html"}
+    ]
+
+    for release in cmssw_releases:
+        release_dir = os.path.join(data_path, release)
+        archs = os.listdir(release_dir)
+        if not archs:
+            continue
+        gcc = archs[0]  # one production arch per release; matches inline shell convention.
+
+        workflows = os.listdir(os.path.join(release_dir, gcc))
+        for workflow in workflows:
+            for category in categories:
+                target = os.path.join(results_path, category, release, gcc, workflow)
+                os.makedirs(target, exist_ok=True)
+
+            src = os.path.join(release_dir, gcc, workflow, "cmdLog_profiling.sh")
+            dst = os.path.join(results_path, "cmdlog", release, gcc, workflow, "cmdLog_profiling.txt")
+            if not os.path.isfile(src):
+                continue
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            shutil.copy2(src, dst)
+
+
+if __name__ == "__main__":
+    main()

--- a/jenkins/scripts/summary/Log_check.py
+++ b/jenkins/scripts/summary/Log_check.py
@@ -1,53 +1,94 @@
+"""Parser for CMSSW step{N}_TimeMemoryInfo.log files.
+
+Extracts per-event TimeEvent (CPU time) and PostProcessPath MemoryCheck
+(VSIZE, RSS) records and joins them on event number. Produces the summary
+text block written to step{N}.txt by `make_get_time_memory_summary.py`.
+
+Public API preserved (TimeMem.Get_TimeMem, TimeMem.summary) since several
+scripts import this module by name.
+"""
+
+from __future__ import annotations
+
 import re
-import sys
-import numpy as np
+
 import pandas as pd
 
-class TimeMem():
 
-	def Get_TimeMem(self,input_data):
+_TIME_EVENT = re.compile(r"^TimeEvent")
+_MEMORY_HEADER = re.compile(r"%MSG-w MemoryCheck:  PostProcessPath")
 
-		matching1 = re.compile('^TimeEvent')
-		matching2 = re.compile('^MemoryCheck')
-		matching3 = re.compile('%MSG-w MemoryCheck:  PostProcessPath')
 
-		self.event1 = []
-		self.time = []
-		self.event2 = []
-		self.vsize = []
-		self.rss = []
+class TimeMem:
+    """Stateful parser. Call Get_TimeMem(path) then summary(out_path)."""
 
-		with open(input_data,'r') as file:
-			flag = 0
-			for i in file:
-				if matching1.match(i):
-					self.event1.append(int(i.split()[1]))
-					self.time.append(float(i.split()[3]))
-				if matching3.match(i):
-					if len(i.split()) < 10:
-						self.event2.append(self.event1[-1])
-					else:
-						self.event2.append(int(i.split()[9]))
-					flag = 1
-					continue;
-				if flag == 1:
-					self.vsize.append(float(i.split()[4]))
-					self.rss.append(float(i.split()[7]))
-					flag = 0
-				
-		print(len(self.vsize),len(self.rss),len(self.event2),len(self.time))
-	
-		df1 = pd.DataFrame({"event":self.event1,"time":self.time})
-		df2 = pd.DataFrame({"event":self.event2,"vsize":self.vsize,"rss":self.rss})
+    def Get_TimeMem(self, input_data: str) -> pd.DataFrame:
+        self.event1: list[int] = []   # event number from TimeEvent
+        self.time:   list[float] = []  # wall-clock per event
+        self.event2: list[int] = []   # event number from MemoryCheck
+        self.vsize:  list[float] = []
+        self.rss:    list[float] = []
 
-		return pd.merge(df1,df2,on="event",how="outer").sort_values(by="event")
+        # State machine: when we see the MemoryCheck header line, the next
+        # non-header line carries vsize/rss numbers.
+        await_mem_values = False
 
-	def summary(self,output_data):
+        with open(input_data, "r") as fh:
+            for line in fh:
+                if _TIME_EVENT.match(line):
+                    parts = line.split()
+                    self.event1.append(int(parts[1]))
+                    self.time.append(float(parts[3]))
+                    continue
 
-		f = open(output_data,"w")
-		f.write("Summary for {} events\n".format(len(self.time)))
-		f.write("Max VSIZ {0} on evt {1} ; max RSS {2} on evt {3}\n".format(max(self.vsize),self.event2[self.vsize.index(max(self.vsize))],max(self.rss),self.event2[self.rss.index(max(self.rss))]))
-		f.write("Time av {0:0.5f} s/evt   max {1} s on evt {2}\n".format(sum(self.time)/len(self.time),max(self.time),self.event1[self.time.index(max(self.time))]))
-		f.write("M1 Time av {0:0.5f} s/evt   max {1} s on evt {2}\n".format(sum(self.time[1:])/len(self.time[1:]),max(self.time[1:]),self.event1[self.time.index(max(self.time[1:]))]))
-		f.write("M8 Time av {0:0.5f} s/evt   max {1} s on evt {2}".format(sum(self.time[8:])/len(self.time[8:]),max(self.time[8:]),self.event1[self.time.index(max(self.time[8:]))]))
-		f.close()
+                if _MEMORY_HEADER.match(line):
+                    parts = line.split()
+                    if len(parts) < 10:
+                        # Header without an explicit event number — reuse the
+                        # most recent TimeEvent's id.
+                        self.event2.append(self.event1[-1])
+                    else:
+                        self.event2.append(int(parts[9]))
+                    await_mem_values = True
+                    continue
+
+                if await_mem_values:
+                    parts = line.split()
+                    self.vsize.append(float(parts[4]))
+                    self.rss.append(float(parts[7]))
+                    await_mem_values = False
+
+        print(len(self.vsize), len(self.rss), len(self.event2), len(self.time))
+
+        df_time = pd.DataFrame({"event": self.event1, "time": self.time})
+        df_mem = pd.DataFrame({"event": self.event2, "vsize": self.vsize, "rss": self.rss})
+        return pd.merge(df_time, df_mem, on="event", how="outer").sort_values(by="event")
+
+    def summary(self, output_data: str) -> None:
+        """Write the canonical step{N}.txt summary block.
+
+        Format must stay byte-for-byte compatible — make_webpage.py renders
+        it as plain text and downstream tooling greps it.
+        """
+        n = len(self.time)
+        max_v = max(self.vsize)
+        max_r = max(self.rss)
+        evt_max_v = self.event2[self.vsize.index(max_v)]
+        evt_max_r = self.event2[self.rss.index(max_r)]
+        max_t = max(self.time)
+        evt_max_t = self.event1[self.time.index(max_t)]
+
+        # M1 = drop first event (warm-up). M8 = drop first 8 (more aggressive warm-up).
+        max_t1 = max(self.time[1:])
+        max_t8 = max(self.time[8:])
+        evt_max_t1 = self.event1[self.time.index(max_t1)]
+        evt_max_t8 = self.event1[self.time.index(max_t8)]
+
+        with open(output_data, "w") as f:
+            f.write(f"Summary for {n} events\n")
+            f.write(f"Max VSIZ {max_v} on evt {evt_max_v} ; max RSS {max_r} on evt {evt_max_r}\n")
+            f.write(f"Time av {sum(self.time) / n:0.5f} s/evt   max {max_t} s on evt {evt_max_t}\n")
+            f.write(f"M1 Time av {sum(self.time[1:]) / (n - 1):0.5f} s/evt   "
+                    f"max {max_t1} s on evt {evt_max_t1}\n")
+            f.write(f"M8 Time av {sum(self.time[8:]) / (n - 8):0.5f} s/evt   "
+                    f"max {max_t8} s on evt {evt_max_t8}")

--- a/jenkins/scripts/summary/found_report.py
+++ b/jenkins/scripts/summary/found_report.py
@@ -1,67 +1,72 @@
+"""Extract the final 'Memory Report:' block from each step's TimeMemoryInfo.log.
+
+Output filename: memory_report_step{N}.txt — must match the inline shell's
+xrdcopy glob `memory_report_step*.txt`.
+"""
+
+from __future__ import annotations
+
 import argparse
 import os
 import sys
 
-def extract_last_memory_report(file_path):
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import _common
+
+
+def extract_last_memory_report(file_path: str) -> str | None:
+    """Return the contiguous trailing block of 'Memory Report:' lines, or None."""
     if not os.path.exists(file_path):
         return None
 
-    report_lines = []
-    found_report = False
-
-    with open(file_path, 'r') as f:
+    with open(file_path, "r") as f:
         lines = f.readlines()
-        
-        for line in reversed(lines):
-            if "Memory Report:" in line:
-                report_lines.append(line.strip())
-                found_report = True
-            elif found_report:
-                break
-    
-    return "\n".join(reversed(report_lines)) if report_lines else None
 
-def main():
-    parser = argparse.ArgumentParser(description="CMSSW Memory Report Extractor")
-    
-    parser.add_argument("--release", required=True, help="CMSSW release")
-    parser.add_argument("--architecture", required=True, help="Architecture")
-    parser.add_argument("--workflow", required=True, help="Workflow ID")
-    parser.add_argument("--base-dir", default="/eos/cms/store/user/cmsbuild/profiling/data", help="Base directory path")
+    report_lines: list[str] = []
+    seen = False
+    for line in reversed(lines):
+        if "Memory Report:" in line:
+            report_lines.append(line.strip())
+            seen = True
+        elif seen:
+            break
 
+    if not report_lines:
+        return None
+    return "\n".join(reversed(report_lines))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="CMSSW Memory Report extractor")
+    parser.add_argument("--release", required=True)
+    parser.add_argument("--architecture", required=True)
+    parser.add_argument("--workflow", required=True)
+    parser.add_argument("--base-dir", default=_common.DATA_DIR)
     args = parser.parse_args()
 
-    steps = ["step3", "step4", "step5"]
     found_any = False
-
-    for step in steps:
-        log_file_path = os.path.join(
-            args.base_dir, 
-            args.release, 
-            args.architecture, 
-            args.workflow, 
-            f"{step}_TimeMemoryInfo.log"
+    for step in ("step3", "step4", "step5"):
+        log_path = _common.step_file(
+            args.release, args.architecture, args.workflow,
+            step, "_TimeMemoryInfo.log", base=args.base_dir,
         )
+        if not os.path.exists(log_path):
+            continue
 
-        if os.path.exists(log_file_path):
-            last_report = extract_last_memory_report(log_file_path)
+        report = extract_last_memory_report(log_path)
+        if report is None:
+            print(f"[{step}] 리포트 섹션을 찾을 수 없습니다.")
+            continue
 
-            if last_report:
-                # 파일명에서 workflow 제거: memory_report_step3.txt
-                output_filename = f"memory_report_{step}.txt"
-                with open(output_filename, "w") as out_f:
-                    out_f.write(last_report)
-                
-                print(f"[{step}] 리포트 추출 완료 -> {output_filename}")
-                found_any = True
-            else:
-                print(f"[{step}] 리포트 섹션을 찾을 수 없습니다.")
-        else:
-            # 로그 파일 자체가 없는 경우 출력 (필요 없으면 생략 가능)
-            pass
+        out = f"memory_report_{step}.txt"
+        with open(out, "w") as f:
+            f.write(report)
+        print(f"[{step}] 리포트 추출 완료 -> {out}")
+        found_any = True
 
     if not found_any:
         print("결과: 생성된 리포트가 없습니다.")
+
 
 if __name__ == "__main__":
     main()

--- a/jenkins/scripts/summary/make_get_time_memory_summary.py
+++ b/jenkins/scripts/summary/make_get_time_memory_summary.py
@@ -1,42 +1,33 @@
+"""For one (release, arch, workflow), parse step{N}_TimeMemoryInfo.log and
+write step{N}.txt summary in the working directory.
+
+The inline shell xrdcopies `step*.txt` from cwd to EOS.
+"""
+
+from __future__ import annotations
+
 import os
-import yaml
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import _common
 import Log_check
 
-DATA_DIR = '/eos/cms/store/user/cmsbuild/profiling/data/' 
 
-def parse_args():
+def main() -> None:
+    args = _common.make_parser("Time/Memory summary writer").parse_args()
+    release, arch, wf = args.release, args.architecture, args.workflow
 
-	import argparse
-	parser = argparse.ArgumentParser()
-	parser.add_argument("--profile-data", type=str, default=DATA_DIR, help="profiling data location")
-	parser.add_argument("--release", type=str, help="CMSSW release", default=None)
-	parser.add_argument("--architecture", type=str, help="architecture for release", default=None)
-	parser.add_argument("--workflow", type=str, help="workflow", default=None)
-	args = parser.parse_args()
-	return args
+    log_parser = Log_check.TimeMem()
+
+    for step in _common.steps_for(wf):
+        tmi = _common.step_file(release, arch, wf, step, "_TimeMemoryInfo.log",
+                                base=args.profile_data)
+        if not os.path.isfile(tmi):
+            continue
+        log_parser.Get_TimeMem(tmi)
+        log_parser.summary(f"{step}.txt")
+
 
 if __name__ == "__main__":
-
-	Log = Log_check.TimeMem()
-
-	args = parse_args()
-
-	release = args.release
-	architecture = args.architecture
-	workflow = args.workflow
-
-	if workflow == "140.56" or workflow == "159.03":
-		steps = ['step2','step3','step4','step5']
-	else:
-		steps = ['step3','step4','step5']
-
-	for step in steps:
-	
-		base = os.path.join(DATA_DIR,release,architecture,workflow)
-		tmi = os.path.join(base,"{}_TimeMemoryInfo.log".format(step))
-	
-		if os.path.isfile(tmi):
-			structure = os.path.join(release,architecture,workflow)
-			os.makedirs(structure, exist_ok=True)
-			Log.Get_TimeMem(tmi)
-			Log.summary("{}.txt".format(step))
+    main()

--- a/jenkins/scripts/summary/make_summary_plot.py
+++ b/jenkins/scripts/summary/make_summary_plot.py
@@ -1,122 +1,136 @@
-from plotly.subplots import make_subplots
-import plotly.graph_objects as go
-import plotly.express as px
-import plotly.io as io
-import sys
-import Log_check
-import pandas as pd
-import numpy as np
-import random
-import yaml
+"""Build per-step Plotly summary (table + time-series + histograms) covering
+every release in the same X-version family.
+
+Output filename: <version>_<step>_<workflow>.html — inline shell xrdcopies
+`*.html` from cwd to summary_plot_html/.
+"""
+
+from __future__ import annotations
+
 import os
-import argparse
+import random
+import sys
 
-DATA_DIR = '/eos/cms/store/user/cmsbuild/profiling/data/'
+import numpy as np
+import plotly.graph_objects as go
+import plotly.io as io
+from plotly.subplots import make_subplots
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--profile-data", type=str, default=DATA_DIR, help="profiling data location")
-parser.add_argument("--release", type=str, help="CMSSW release", default=None)
-parser.add_argument("--architecture", type=str, help="architecture for release", default=None)
-parser.add_argument("--workflow", type=str, help="workflow", default=None)
-args = parser.parse_args()
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import _common
+import Log_check
 
-release = args.release
-architecture = args.architecture
-workflow = args.workflow
 
-log_object = Log_check.TimeMem()
+SUBPLOT_TITLES = [
+    "Summary Table",
+    "(RSS)Memory Profile", "(VSIZE)Memory Profile", "average CPU Time Profile",
+    "(RSS)Memory Profile", "(VSIZE)Memory Profile", "CPU Time Profile",
+]
 
-subplot_title=["Summary Table", "(RSS)Memory Profile", "(VSIZE)Memory Profile", "average CPU Time Profile", "(RSS)Memory Profile", "(VSIZE)Memory Profile", "CPU Time Profile"]
 
-version = '_'.join(release.split('_')[:3])
+def family_releases(version_prefix: str, base: str) -> list[str]:
+    """Releases in the same version family (e.g. all 'CMSSW_14_0' tags)."""
+    return [r for r in os.listdir(base) if version_prefix in r]
 
-if workflow == "140.56" or workflow == "159.03":
-	steps = ['step2','step3','step4','step5']
-else:
-	steps = ['step3','step4','step5']
 
-for step in steps:
+def main() -> None:
+    args = _common.make_parser(
+        "Per-version summary plot builder",
+        need=("release", "workflow"),
+    ).parse_args()
+    release, workflow = args.release, args.workflow
+    base = args.profile_data
 
-	fig = make_subplots(rows=3, cols=3,
-		row_heights=[0.2,0.4,0.4],
-		subplot_titles=subplot_title,
-		start_cell="top-left",
-		vertical_spacing=0.1,
-		specs=[[{"colspan":3,"type":"table"},None,None],
-			[{},{},{}],
-			[{},{},{}]]
-	)
+    log_parser = Log_check.TimeMem()
+    version_prefix = "_".join(release.split("_")[:3])  # e.g. CMSSW_14_0
 
-	max_rss=[]
-	max_vsize=[]
-	max_time=[]
-	avrg_time=[]
+    for step in _common.steps_for(workflow):
+        fig = make_subplots(
+            rows=3, cols=3,
+            row_heights=[0.2, 0.4, 0.4],
+            subplot_titles=SUBPLOT_TITLES,
+            start_cell="top-left",
+            vertical_spacing=0.1,
+            specs=[
+                [{"colspan": 3, "type": "table"}, None, None],
+                [{}, {}, {}],
+                [{}, {}, {}],
+            ],
+        )
 
-	cmssw_version = []
+        cmssw_versions: list[str] = []
+        max_rss: list[str] = []
+        max_vsize: list[str] = []
+        max_time: list[str] = []
+        avg_time: list[str] = []
 
-	for cmssw in [x for x in os.listdir(DATA_DIR) if version in x]:
+        for cmssw in family_releases(version_prefix, base):
+            arch = os.listdir(os.path.join(base, cmssw))[0]
+            tmi = _common.step_file(cmssw, arch, workflow, step, "_TimeMemoryInfo.log", base=base)
+            if not os.path.isfile(tmi):
+                continue
 
-		architecture = os.listdir(os.path.join(DATA_DIR,cmssw))[0]
-		path = os.path.join(DATA_DIR,cmssw,architecture,workflow,'{}_TimeMemoryInfo.log'.format(step))
-		if not os.path.isfile(path):
-			continue
-		df = log_object.Get_TimeMem(path)
-		if len(df['event']) == 0:
-			continue
-		hex_number = '#'+str(hex(random.randint(0,16777215)))[2:].zfill(6)
-		x_axis = np.arange(len(df))
+            df = log_parser.Get_TimeMem(tmi)
+            if len(df["event"]) == 0:
+                continue
 
-		fig.add_trace(go.Scatter(x=x_axis,y=df["rss"],mode="lines",line=dict(color=hex_number,width=1),legendgroup=cmssw,hovertext=cmssw,name=cmssw),row=2,col=1)
-		fig.add_trace(go.Scatter(x=x_axis,y=df["vsize"],mode="lines",line=dict(color=hex_number,width=1),legendgroup=cmssw,hovertext=cmssw,name=cmssw,showlegend=False),row=2,col=2)
-		fig.add_trace(go.Scatter(x=x_axis,y=df["time"],mode="lines",line=dict(color=hex_number,width=1),legendgroup=cmssw,hovertext=cmssw,name=cmssw,showlegend=False),row=2,col=3)
-		fig.add_trace(go.Histogram(x=df["rss"],nbinsx=20,bingroup=1,marker_color=hex_number,opacity=0.50,legendgroup=cmssw,hovertext=cmssw,name=cmssw,showlegend=False),row=3,col=1)
-		fig.add_trace(go.Histogram(x=df["vsize"],nbinsx=20,bingroup=2,marker_color=hex_number,opacity=0.50,legendgroup=cmssw,hovertext=cmssw,name=cmssw,showlegend=False),row=3,col=2)
-		fig.add_trace(go.Histogram(x=df["time"],nbinsx=20,bingroup=3,marker_color=hex_number,opacity=0.50,legendgroup=cmssw,hovertext=cmssw,name=cmssw,showlegend=False),row=3,col=3)
-		max_rss.append("{0}({1})".format(df['rss'].max(),df['event'][df['rss'].idxmax()]))
-		max_vsize.append("{0}({1})".format(df['vsize'].max(),df['event'][df['vsize'].idxmax()]))
-		max_time.append("{0}({1})".format(df['time'].max(),df['event'][df['time'].idxmax()]))
-		avrg_time.append(str(round(df['time'].sum()/len(df['time']),4)))
-		cmssw_version.append(cmssw)
+            color = "#" + format(random.randint(0, 0xFFFFFF), "06x")
+            x_axis = np.arange(len(df))
 
-	if len(cmssw_version) == 0:
-		continue
+            common_line = dict(mode="lines", line=dict(color=color, width=1),
+                               legendgroup=cmssw, hovertext=cmssw, name=cmssw)
+            fig.add_trace(go.Scatter(x=x_axis, y=df["rss"], **common_line), row=2, col=1)
+            fig.add_trace(go.Scatter(x=x_axis, y=df["vsize"], showlegend=False, **common_line), row=2, col=2)
+            fig.add_trace(go.Scatter(x=x_axis, y=df["time"], showlegend=False, **common_line), row=2, col=3)
 
-	fig.add_trace(go.Table(header=dict(values=['VERSION', '(RSS)MaxMemory(evt)','(VSIZE)MaxMemory(evt)','AverageTime','MaxTime(evt)']),
-		cells=dict(height=30,values=[cmssw_version,max_rss,max_vsize,avrg_time,max_time])),
-		row=1,col=1)
+            common_hist = dict(marker_color=color, opacity=0.50,
+                               legendgroup=cmssw, hovertext=cmssw, name=cmssw, showlegend=False)
+            fig.add_trace(go.Histogram(x=df["rss"], nbinsx=20, bingroup=1, **common_hist), row=3, col=1)
+            fig.add_trace(go.Histogram(x=df["vsize"], nbinsx=20, bingroup=2, **common_hist), row=3, col=2)
+            fig.add_trace(go.Histogram(x=df["time"], nbinsx=20, bingroup=3, **common_hist), row=3, col=3)
 
-	fig.update_layout(barmode='overlay')
-	fig.update_layout(
-	        height=1500,
-	        width=1500,
-	        title={
-	        'text':"Summary of Time and Memory test : {0}_X_{1}".format(version,step),
-	        'x':0.5,
-	        'y':0.98,
-	        'xanchor':'center',
-	        'yanchor':'top',
-	        'font':dict(size=20)},
-	        legend=dict(
-	        orientation="h",
-	        yanchor="bottom",
-	        y=0.78,
-	        xanchor="right",
-	        x=1
-	))
+            max_rss.append(f"{df['rss'].max()}({df['event'][df['rss'].idxmax()]})")
+            max_vsize.append(f"{df['vsize'].max()}({df['event'][df['vsize'].idxmax()]})")
+            max_time.append(f"{df['time'].max()}({df['event'][df['time'].idxmax()]})")
+            avg_time.append(str(round(df["time"].sum() / len(df["time"]), 4)))
+            cmssw_versions.append(cmssw)
 
-	fig.update_xaxes(title_text="ith event",row=2,col=1)
-	fig.update_xaxes(title_text="ith event",row=2,col=2)
-	fig.update_xaxes(title_text="ith event",row=2,col=3)
-	fig.update_xaxes(title_text="Memory(MB)",row=3,col=1)
-	fig.update_xaxes(title_text="Memory(MB)",row=3,col=2)
-	fig.update_xaxes(title_text="Time(s)",row=3,col=3)
-	
-	fig.update_yaxes(title_text="Memory(MB)",row=2,col=1)
-	fig.update_yaxes(title_text="Memory(MB)",row=2,col=2)
-	fig.update_yaxes(title_text="Time(s)",type="log",row=2,col=3)
-	fig.update_yaxes(title_text="Number of events",row=3,col=1)
-	fig.update_yaxes(title_text="Number of events",row=3,col=2)
-	fig.update_yaxes(title_text="Number of events",row=3,col=3)
+        if not cmssw_versions:
+            continue
 
-	output = "{0}_{1}_{2}.html".format(version,step,workflow)
-	io.write_html(fig,output)
+        fig.add_trace(
+            go.Table(
+                header=dict(values=["VERSION", "(RSS)MaxMemory(evt)", "(VSIZE)MaxMemory(evt)",
+                                    "AverageTime", "MaxTime(evt)"]),
+                cells=dict(height=30, values=[cmssw_versions, max_rss, max_vsize, avg_time, max_time]),
+            ),
+            row=1, col=1,
+        )
+
+        fig.update_layout(
+            barmode="overlay",
+            height=1500, width=1500,
+            title=dict(
+                text=f"Summary of Time and Memory test : {version_prefix}_X_{step}",
+                x=0.5, y=0.98, xanchor="center", yanchor="top", font=dict(size=20),
+            ),
+            legend=dict(orientation="h", yanchor="bottom", y=0.78, xanchor="right", x=1),
+        )
+
+        for col in (1, 2, 3):
+            fig.update_xaxes(title_text="ith event", row=2, col=col)
+        fig.update_xaxes(title_text="Memory(MB)", row=3, col=1)
+        fig.update_xaxes(title_text="Memory(MB)", row=3, col=2)
+        fig.update_xaxes(title_text="Time(s)", row=3, col=3)
+        fig.update_yaxes(title_text="Memory(MB)", row=2, col=1)
+        fig.update_yaxes(title_text="Memory(MB)", row=2, col=2)
+        fig.update_yaxes(title_text="Time(s)", type="log", row=2, col=3)
+        for col in (1, 2, 3):
+            fig.update_yaxes(title_text="Number of events", row=3, col=col)
+
+        out = f"{version_prefix}_{step}_{workflow}.html"
+        io.write_html(fig, out)
+
+
+if __name__ == "__main__":
+    main()

--- a/jenkins/scripts/summary/make_summary_plot.py
+++ b/jenkins/scripts/summary/make_summary_plot.py
@@ -76,23 +76,31 @@ def _read_max_memory_bytes(path: str) -> int | None:
         return None
 
 
-# Per-step colour palette for the bar chart. step3 (RECO) is the headline pass.
-_STEP_COLOURS = {
-    "step2": "#94a3b8", "step3": "#2563eb", "step4": "#16a34a", "step5": "#f97316",
+# Per-step style for the trend lines. Different markers so the three traces
+# remain distinguishable in B/W or for readers who don't see hue. Javier
+# (2025-12-XX) asked for line+marker traces grouped per workflow so a
+# gradual rise vs. sudden jump in peak memory is visible at a glance.
+_STEP_STYLE = {
+    "step2": {"colour": "#94a3b8", "symbol": "diamond",       "label": "step2"},
+    "step3": {"colour": "#2563eb", "symbol": "circle",        "label": "step3 (RECO/AOD)"},
+    "step4": {"colour": "#16a34a", "symbol": "square",        "label": "step4 (PAT/MiniAOD)"},
+    "step5": {"colour": "#f97316", "symbol": "triangle-up",   "label": "step5 (NanoAOD)"},
 }
 
 
 def write_family_maxmem_plot(version_prefix: str, profile_data: str) -> None:
-    """Family-level grouped-bar Plotly chart of MaxMemoryPreload values.
+    """Family-level line+marker Plotly chart of MaxMemoryPreload values.
 
     For every release in the family × workflow it has × step it analyses,
     pull the trailing 'max memory used:' from
     RESULT_PATH/Time_Mem_Summary/<rel>/<arch>/<wf>/memory_report_step{N}.txt
     (already populated by found_report.py + the inline-shell xrdcopy).
 
-    Renders one stacked subplot per workflow, x=release ordered by version,
-    y=peak memory in GB, colour=step. Output: <version_prefix>_maxmem.html
-    in cwd; the inline-shell xrdcopy of `*.html` puts it in summary_plot_html/.
+    Renders one subplot per workflow, x=release ordered by version,
+    y=peak memory in GB. Each step is a separate trace with its own marker
+    symbol so a sudden jump or gradual rise across releases is obvious.
+    Output: <version_prefix>_maxmem.html in cwd; the inline-shell xrdcopy
+    of `*.html` puts it in summary_plot_html/.
     """
     rows = []
     for cmssw in family_releases(version_prefix, profile_data):
@@ -132,42 +140,69 @@ def write_family_maxmem_plot(version_prefix: str, profile_data: str) -> None:
         vertical_spacing=0.10,
     )
 
+    # Track which steps have been added to the legend so the same step in
+    # different subplots reuses one legend entry.
+    legend_seen: set[str] = set()
+
     for i, wf in enumerate(workflows, 1):
         wf_rows = [r for r in rows if r["workflow"] == wf]
-        steps_present = sorted({r["step"] for r in wf_rows})
-        # Releases that contributed at least one bar in this workflow,
-        # ordered by version key.
-        rels = sorted({r["release"] for r in wf_rows},
-                      key=_release_sort_key)
-        for step in steps_present:
+        # All releases that appeared in any step of this workflow,
+        # ordered by version. None gaps mean "this step wasn't analysed
+        # for that release"; connectgaps keeps the line continuous.
+        rels = sorted({r["release"] for r in wf_rows}, key=_release_sort_key)
+        for step in ("step2", "step3", "step4", "step5"):
             ys = []
+            present = False
             for rel in rels:
                 hit = next((r for r in wf_rows
                             if r["release"] == rel and r["step"] == step), None)
-                ys.append(hit["max_used_gb"] if hit else None)
-            fig.add_trace(go.Bar(
-                x=rels,
-                y=ys,
-                name=step,
-                marker_color=_STEP_COLOURS.get(step, "#666"),
+                if hit:
+                    present = True
+                    ys.append(hit["max_used_gb"])
+                else:
+                    ys.append(None)
+            if not present:
+                continue
+            style = _STEP_STYLE[step]
+            show_legend = step not in legend_seen
+            legend_seen.add(step)
+            fig.add_trace(go.Scatter(
+                x=rels, y=ys,
+                mode="lines+markers",
+                name=style["label"],
                 legendgroup=step,
-                showlegend=(i == 1),
-                hovertemplate="%{x}<br>" + step + ": %{y:.2f} GB<extra></extra>",
+                showlegend=show_legend,
+                line=dict(color=style["colour"], width=2),
+                marker=dict(symbol=style["symbol"], size=10,
+                            color=style["colour"],
+                            line=dict(color="white", width=1)),
+                connectgaps=True,
+                hovertemplate=("<b>%{x}</b><br>" + style["label"] +
+                               ": %{y:.3f} GB<extra></extra>"),
             ), row=i, col=1)
 
+    # Layout: title on top, legend in a single row directly below the title
+    # but still above all subplots. The extra top margin keeps the legend
+    # from overlapping the first workflow's plot area.
     fig.update_layout(
-        barmode="group",
         title=dict(
-            text=f"Max Memory (AllocMonitor) — {version_prefix}_X",
+            text=f"Max Memory (AllocMonitor) trend — {version_prefix}_X",
             x=0.5, xanchor="center", font=dict(size=18),
         ),
-        height=320 * len(workflows) + 100,
+        height=340 * len(workflows) + 160,
         width=1400,
-        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
-        margin=dict(l=70, r=30, t=80, b=40),
+        legend=dict(
+            orientation="h",
+            yanchor="bottom", y=1.04,
+            xanchor="center", x=0.5,
+            bgcolor="rgba(0,0,0,0)",
+            font=dict(size=12),
+        ),
+        margin=dict(l=70, r=30, t=140, b=40),
+        hovermode="x unified",
     )
     for i in range(1, len(workflows) + 1):
-        fig.update_yaxes(title_text="Peak memory (GB)", row=i, col=1)
+        fig.update_yaxes(title_text="Peak memory (GB)", row=i, col=1, rangemode="tozero")
         fig.update_xaxes(tickangle=-45, row=i, col=1)
 
     out = f"{version_prefix}_maxmem.html"

--- a/jenkins/scripts/summary/make_summary_plot.py
+++ b/jenkins/scripts/summary/make_summary_plot.py
@@ -1,14 +1,17 @@
 """Build per-step Plotly summary (table + time-series + histograms) covering
-every release in the same X-version family.
+every release in the same X-version family. Also build a family-level
+MaxMemoryPreload (AllocMonitor) bar chart per Javier's 2025-11-26 request.
 
-Output filename: <version>_<step>_<workflow>.html — inline shell xrdcopies
-`*.html` from cwd to summary_plot_html/.
+Output filenames (all land in summary_plot_html/ via the inline shell glob):
+- <version>_<step>_<workflow>.html  → existing per-step plot
+- <version>_maxmem.html             → new family-level peak-memory plot
 """
 
 from __future__ import annotations
 
 import os
 import random
+import re
 import sys
 
 import numpy as np
@@ -31,6 +34,144 @@ SUBPLOT_TITLES = [
 def family_releases(version_prefix: str, base: str) -> list[str]:
     """Releases in the same version family (e.g. all 'CMSSW_14_0' tags)."""
     return [r for r in os.listdir(base) if version_prefix in r]
+
+
+def _release_sort_key(release: str) -> tuple:
+    """Sort key matching the rest of the pipeline (pre0..pre6 < base < patch1..)."""
+    parts = release.split("_")
+    try:
+        major = int(parts[1]); minor = int(parts[2]); patch = int(parts[3])
+    except (IndexError, ValueError):
+        major = minor = patch = -1
+    suffix = parts[4] if len(parts) >= 5 else ""
+    if suffix.startswith("pre"):
+        try: sub = -1000 + int(suffix[3:])
+        except ValueError: sub = -500
+    elif suffix.startswith("patch"):
+        try: sub = int(suffix[5:])
+        except ValueError: sub = 500
+    elif suffix == "":
+        sub = 0
+    else:
+        sub = 750
+    return (major, minor, patch, sub, release)
+
+
+_MAX_MEM_RE = re.compile(r"max memory used:\s*(-?\d+)")
+
+
+def _read_max_memory_bytes(path: str) -> int | None:
+    """Last 'max memory used: <bytes>' value in the file, or None."""
+    try:
+        with open(path) as f:
+            text = f.read()
+    except OSError:
+        return None
+    matches = _MAX_MEM_RE.findall(text)
+    if not matches:
+        return None
+    try:
+        return int(matches[-1])
+    except ValueError:
+        return None
+
+
+# Per-step colour palette for the bar chart. step3 (RECO) is the headline pass.
+_STEP_COLOURS = {
+    "step2": "#94a3b8", "step3": "#2563eb", "step4": "#16a34a", "step5": "#f97316",
+}
+
+
+def write_family_maxmem_plot(version_prefix: str, profile_data: str) -> None:
+    """Family-level grouped-bar Plotly chart of MaxMemoryPreload values.
+
+    For every release in the family × workflow it has × step it analyses,
+    pull the trailing 'max memory used:' from
+    RESULT_PATH/Time_Mem_Summary/<rel>/<arch>/<wf>/memory_report_step{N}.txt
+    (already populated by found_report.py + the inline-shell xrdcopy).
+
+    Renders one stacked subplot per workflow, x=release ordered by version,
+    y=peak memory in GB, colour=step. Output: <version_prefix>_maxmem.html
+    in cwd; the inline-shell xrdcopy of `*.html` puts it in summary_plot_html/.
+    """
+    rows = []
+    for cmssw in family_releases(version_prefix, profile_data):
+        cmssw_path = os.path.join(profile_data, cmssw)
+        if not os.path.isdir(cmssw_path):
+            continue
+        archs = os.listdir(cmssw_path)
+        if not archs:
+            continue
+        arch = archs[0]
+        arch_path = os.path.join(cmssw_path, arch)
+        if not os.path.isdir(arch_path):
+            continue
+        for workflow in os.listdir(arch_path):
+            for step in _common.steps_for(workflow):
+                mem_path = _common.result_subdir(
+                    "Time_Mem_Summary", cmssw, arch, workflow,
+                    f"memory_report_{step}.txt")
+                if not os.path.isfile(mem_path):
+                    continue
+                value = _read_max_memory_bytes(mem_path)
+                if value is None:
+                    continue
+                rows.append({
+                    "release": cmssw, "workflow": workflow, "step": step,
+                    "max_used_gb": value / 1e9,
+                    "key": _release_sort_key(cmssw),
+                })
+    if not rows:
+        return
+
+    # Group rows by workflow, sort releases within each workflow by version.
+    workflows = sorted({r["workflow"] for r in rows})
+    fig = make_subplots(
+        rows=len(workflows), cols=1,
+        subplot_titles=[f"Workflow {wf}" for wf in workflows],
+        vertical_spacing=0.10,
+    )
+
+    for i, wf in enumerate(workflows, 1):
+        wf_rows = [r for r in rows if r["workflow"] == wf]
+        steps_present = sorted({r["step"] for r in wf_rows})
+        # Releases that contributed at least one bar in this workflow,
+        # ordered by version key.
+        rels = sorted({r["release"] for r in wf_rows},
+                      key=_release_sort_key)
+        for step in steps_present:
+            ys = []
+            for rel in rels:
+                hit = next((r for r in wf_rows
+                            if r["release"] == rel and r["step"] == step), None)
+                ys.append(hit["max_used_gb"] if hit else None)
+            fig.add_trace(go.Bar(
+                x=rels,
+                y=ys,
+                name=step,
+                marker_color=_STEP_COLOURS.get(step, "#666"),
+                legendgroup=step,
+                showlegend=(i == 1),
+                hovertemplate="%{x}<br>" + step + ": %{y:.2f} GB<extra></extra>",
+            ), row=i, col=1)
+
+    fig.update_layout(
+        barmode="group",
+        title=dict(
+            text=f"Max Memory (AllocMonitor) — {version_prefix}_X",
+            x=0.5, xanchor="center", font=dict(size=18),
+        ),
+        height=320 * len(workflows) + 100,
+        width=1400,
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+        margin=dict(l=70, r=30, t=80, b=40),
+    )
+    for i in range(1, len(workflows) + 1):
+        fig.update_yaxes(title_text="Peak memory (GB)", row=i, col=1)
+        fig.update_xaxes(tickangle=-45, row=i, col=1)
+
+    out = f"{version_prefix}_maxmem.html"
+    io.write_html(fig, out)
 
 
 def main() -> None:
@@ -130,6 +271,10 @@ def main() -> None:
 
         out = f"{version_prefix}_{step}_{workflow}.html"
         io.write_html(fig, out)
+
+    # Family-level MaxMemoryPreload chart. Idempotent — every (release, wf)
+    # invocation rewrites the same <family>_maxmem.html with the latest data.
+    write_family_maxmem_plot(version_prefix, base)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Centralize the duplicated boilerplate (DATA_DIR/RESULT_PATH constants, argparse surface, workflow-step gating, path builders) into a single jenkins/scripts/_common.py and rewrite the per-step scripts on top of it.

Why: the inline shell in release-analyze-reco-profiling repeats the same 4-arg argparse and EOS path concatenations across nine scripts, making behaviour drift hard to spot. This change preserves the I/O contract the inline shell observes (CLI flags, output filenames in cwd, EOS read paths) while making each script readable.

Also fixes the cmdLog cp errors in make_jenkins_env.py: the original used os.system("cp ...") without ensuring the parent directory existed, which spammed dozens of "cannot create regular file" lines per build. Now uses shutil.copy2 with explicit os.makedirs first.

Out of scope (intentionally untouched):
- *.awk comparison logic
- igprof/{make_igprof_data,doEvent}.py (commented out in inline shell)
- erase.py (not called)
- test/scripts/ (parallel sandbox, not exercised)
- cms-reco-profiling-v2/ (separate refactor)

Verified locally against CMSSW_16_0_3 / CMSSW_16_0_4 fixture:
- Log_check parsing produces same 400-event summary
- found_report.py emits memory_report_step{N}.txt (matches xrdcopy glob)
- make_get_time_memory_summary.py emits step{N}.txt with byte-identical body
- make_compare_data.py runs N03 between 16_0_3 and 16_0_4, emits CMSSW_16_0_4/el8_amd64_gcc13/12634.21/step{3,4,5}.txt with the canonical "Job total: X s/ev ==> Y s/ev" trailer